### PR TITLE
Allow to get executions results and Improved Workflows run to work in parallel 

### DIFF
--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -50,21 +50,21 @@ const (
 	// Alien4Cloud for an application
 	DefaultEnvironmentName = "Environment"
 	// ApplicationDeploymentInProgress a4c status
-	ApplicationDeploymentInProgress = "deployment_in_progress"
+	ApplicationDeploymentInProgress = "DEPLOYMENT_IN_PROGRESS"
 	// ApplicationDeployed a4c status
-	ApplicationDeployed = "deployed"
+	ApplicationDeployed = "DEPLOYED"
 	// ApplicationUndeploymentInProgress a4c status
-	ApplicationUndeploymentInProgress = "undeployment_in_progress"
+	ApplicationUndeploymentInProgress = "UNDEPLOYMENT_IN_PROGRESS"
 	// ApplicationUndeployed a4c status
-	ApplicationUndeployed = "undeployed"
+	ApplicationUndeployed = "UNDEPLOYED"
 	// ApplicationError a4c status
-	ApplicationError = "failure"
+	ApplicationError = "FAILURE"
 	// ApplicationUpdateError a4c status
-	ApplicationUpdateError = "update_failure"
+	ApplicationUpdateError = "UPDATE_FAILURE"
 	// ApplicationUpdated a4c status
-	ApplicationUpdated = "updated"
+	ApplicationUpdated = "UPDATED"
 	// ApplicationUpdateInProgress a4c status
-	ApplicationUpdateInProgress = "update_in_progress"
+	ApplicationUpdateInProgress = "UPDATE_IN_PROGRESS"
 
 	// WorkflowSucceeded workflow a4c status
 	WorkflowSucceeded = "SUCCEEDED"

--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -222,13 +222,7 @@ func (c *a4cClient) Logout(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
-	}
-
-	return nil
+	return processA4CResponse(response, nil, http.StatusOK)
 }
 
 // ApplicationService retrieves the Application Service
@@ -330,11 +324,5 @@ func (r *restClient) login(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
-	}
-
-	return nil
+	return processA4CResponse(response, nil, http.StatusOK)
 }

--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -225,7 +225,7 @@ func (c *a4cClient) Logout(ctx context.Context) error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil
@@ -333,7 +333,7 @@ func (r *restClient) login(ctx context.Context) error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -484,8 +484,12 @@ type LogFilter struct {
 // WorkflowExecution represents rest api workflow execution
 type WorkflowExecution struct {
 	ID                  string `json:"id"`
+	DeploymentID        string `json:"deploymentId"`
+	WorkflowID          string `json:"workflowId"`
+	WorkflowName        string `json:"workflowName"`
 	DisplayWorkflowName string `json:"displayWorkflowName"`
 	Status              string `json:"status"`
+	HasFailedTasks      bool   `json:"hasFailedTasks"`
 }
 
 // Time represents the timestamp field from A4C
@@ -536,4 +540,11 @@ type topologyEditorPolicies struct {
 	topologyEditorExecuteRequest
 	PolicyName   string `json:"policyName"`
 	PolicyTypeID string `json:"policyTypeId,omitempty"`
+}
+
+// FacetedSearchResult allows to retrieve pagination information
+type FacetedSearchResult struct {
+	TotalResults int `json:"totalResults"`
+	From         int `json:"from"`
+	To           int `json:"to"`
 }

--- a/alien4cloud/application.go
+++ b/alien4cloud/application.go
@@ -83,7 +83,7 @@ func (a *applicationService) CreateAppli(ctx context.Context, appName string, ap
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusCreated {
-		return appID, getError(response.Body)
+		return appID, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -132,7 +132,7 @@ func (a *applicationService) GetEnvironmentIDbyName(ctx context.Context, appID s
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -193,7 +193,7 @@ func (a *applicationService) IsApplicationExist(ctx context.Context, application
 		return false, nil
 
 	default:
-		return false, getError(response.Body)
+		return false, getError(response)
 	}
 }
 
@@ -226,7 +226,7 @@ func (a *applicationService) GetApplicationsID(ctx context.Context, filter strin
 
 	switch response.StatusCode {
 	default:
-		return nil, getError(response.Body)
+		return nil, getError(response)
 
 	case http.StatusNotFound:
 		// No application with this filter have been found
@@ -301,7 +301,7 @@ func (a *applicationService) GetApplicationByID(ctx context.Context, id string) 
 
 	switch response.StatusCode {
 	default:
-		return nil, getError(response.Body)
+		return nil, getError(response)
 
 	case http.StatusNotFound:
 		// No application with this filter have been found
@@ -357,7 +357,7 @@ func (a *applicationService) DeleteApplication(ctx context.Context, appID string
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil
@@ -393,7 +393,7 @@ func (a *applicationService) SetTagToApplication(ctx context.Context, applicatio
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil

--- a/alien4cloud/catalog.go
+++ b/alien4cloud/catalog.go
@@ -3,10 +3,8 @@ package alien4cloud
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -111,22 +109,17 @@ func (cs *catalogService) UploadCSAR(ctx context.Context, csar io.Reader, worksp
 		return c, getError(response.Body)
 	}
 
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return c, errors.Wrap(err, "Cannot read the body of the uploaded CSAR description")
-	}
 	var res struct {
 		Data struct {
 			CSAR   CSAR                      `json:"csar,omitempty"`
 			Errors map[string][]ParsingError `json:"errors,omitempty"`
 		} `json:"data"`
 	}
-
-	if err = json.Unmarshal([]byte(responseBody), &res); err != nil {
+	err = readBodyData(response, &res)
+	if err != nil {
 		return c, errors.Wrap(err, "Cannot convert the body of the uploaded CSAR description")
 	}
-	err = nil
+
 	if len(res.Data.Errors) > 0 {
 		err = &parsingErr{res.Data.Errors}
 	}

--- a/alien4cloud/catalog.go
+++ b/alien4cloud/catalog.go
@@ -102,12 +102,6 @@ func (cs *catalogService) UploadCSAR(ctx context.Context, csar io.Reader, worksp
 	if err != nil {
 		return c, errors.Wrap(err, "Cannot send a request in order to upload a CSAR")
 	}
-	defer response.Body.Close()
-
-	// Should be a created status but alien actually returns a OK status...
-	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
-		return c, getError(response)
-	}
 
 	var res struct {
 		Data struct {
@@ -115,7 +109,8 @@ func (cs *catalogService) UploadCSAR(ctx context.Context, csar io.Reader, worksp
 			Errors map[string][]ParsingError `json:"errors,omitempty"`
 		} `json:"data"`
 	}
-	err = readCloseResponseBody(response, &res)
+
+	err = processA4CResponse(response, &res, http.StatusOK)
 	if err != nil {
 		return c, errors.Wrap(err, "Cannot convert the body of the uploaded CSAR description")
 	}

--- a/alien4cloud/catalog.go
+++ b/alien4cloud/catalog.go
@@ -106,7 +106,7 @@ func (cs *catalogService) UploadCSAR(ctx context.Context, csar io.Reader, worksp
 
 	// Should be a created status but alien actually returns a OK status...
 	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
-		return c, getError(response.Body)
+		return c, getError(response)
 	}
 
 	var res struct {
@@ -115,7 +115,7 @@ func (cs *catalogService) UploadCSAR(ctx context.Context, csar io.Reader, worksp
 			Errors map[string][]ParsingError `json:"errors,omitempty"`
 		} `json:"data"`
 	}
-	err = readBodyData(response, &res)
+	err = readCloseResponseBody(response, &res)
 	if err != nil {
 		return c, errors.Wrap(err, "Cannot convert the body of the uploaded CSAR description")
 	}

--- a/alien4cloud/catalog_test.go
+++ b/alien4cloud/catalog_test.go
@@ -57,7 +57,7 @@ func Test_catalogService_UploadCSAR(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusOK)
 		w.Write(b)
 	}))
 	defer ts.Close()

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -86,28 +85,12 @@ func (d *deploymentService) GetLocationsMatching(ctx context.Context, topologyID
 		return nil, errors.Wrapf(err, "Failed to get locations matching topology for application '%s' in '%s' environment",
 			topologyID, envID)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrapf(err, "Cannot read response to request on locations matching topology '%s' in '%s' environment",
-			topologyID, envID)
-	}
 	var res struct {
 		Data []LocationMatch `json:"data"`
 	}
-
-	if err = json.Unmarshal([]byte(responseBody), &res); err != nil {
-		return nil, errors.Wrapf(err, "Cannot convert the body response to request on locations matching topology '%s' in '%s' environment",
-			topologyID, envID)
-	}
-
-	return res.Data, err
+	err = processA4CResponse(response, &res, http.StatusOK)
+	return res.Data, errors.Wrapf(err, "Cannot convert the body response to request on locations matching topology '%s' in '%s' environment",
+		topologyID, envID)
 }
 
 // DeployApplication Deploy the given application in the given environment using the given orchestrator
@@ -163,12 +146,10 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 	if err != nil {
 		return errors.Wrap(err, "Unable to send a request to set the location in order to deploy an application")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
+	err = processA4CResponse(response, nil, http.StatusOK)
+	if err != nil {
+		return errors.Wrap(err, "Unable to send a request to set the location in order to deploy an application")
 	}
-
 	// Deploy the application a4cApplicationDeployhRequestIn
 	appDeployBody, err := json.Marshal(
 		ApplicationDeployRequest{
@@ -186,12 +167,7 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 	if err != nil {
 		return errors.Wrap(err, "Unable to send a request to deploy the application")
 	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
-	}
-
-	return nil
+	return processA4CResponse(response, nil, http.StatusOK)
 }
 
 // UpdateApplication updates an application with the latest topology version
@@ -206,13 +182,8 @@ func (d *deploymentService) UpdateApplication(ctx context.Context, appID, envID 
 	if err != nil {
 		return errors.Wrapf(err, "Unable to send a request to update application %s", appID)
 	}
-	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
-	}
-
-	return nil
+	return processA4CResponse(response, nil, http.StatusOK)
 }
 
 // GetDeploymentList returns the deployment list for the given appID and envID
@@ -228,17 +199,6 @@ func (d *deploymentService) GetDeploymentList(ctx context.Context, appID string,
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to send request to get deployment list")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrapf(err, "Cannot read the body when getting deployment list")
-	}
 
 	var deploymentListResponse struct {
 		Data struct {
@@ -248,11 +208,9 @@ func (d *deploymentService) GetDeploymentList(ctx context.Context, appID string,
 			TotalResults int `json:"totalResults"`
 		} `json:"data"`
 	}
-
-	err = json.Unmarshal(responseBody, &deploymentListResponse)
-
+	err = processA4CResponse(response, &deploymentListResponse, http.StatusOK)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to unmarshal the deployment list")
+		return nil, errors.Wrapf(err, "Unable to get deployment list response for application %q environment %q", appID, envID)
 	}
 
 	var deploymentList []Deployment
@@ -277,13 +235,7 @@ func (d *deploymentService) UndeployApplication(ctx context.Context, appID strin
 	if err != nil {
 		return errors.Wrap(err, "Unable to send request to undeploy A4C application")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return getError(response)
-	}
-
-	return nil
+	return processA4CResponse(response, nil, http.StatusOK)
 }
 
 // WaitUntilStateIs Waits until the state of an Alien4Cloud application is one of the given statuses as parameter and returns the actual status.
@@ -330,27 +282,13 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 	if err != nil {
 		return "", errors.Wrap(err, "Cannot send a request to get the deployment status")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return "", getError(response)
-	}
 
 	var statusResponse struct {
-		Data  string `json:"data"`
-		Error *Error `json:"error,omitempty"`
+		Data string `json:"data"`
 	}
 
-	err = readCloseResponseBody(response, &statusResponse)
-	if err != nil {
-		return "", errors.Wrapf(err, "Unable to unmarshal the deployment status")
-	}
-
-	if statusResponse.Error != nil {
-		return "", errors.New(statusResponse.Error.Message)
-	}
-
-	return statusResponse.Data, nil
+	err = processA4CResponse(response, &statusResponse, http.StatusOK)
+	return statusResponse.Data, errors.Wrapf(err, "Unable to get deployment status for application %q environment %q", applicationID, environmentID)
 
 }
 
@@ -367,11 +305,6 @@ func (d *deploymentService) GetCurrentDeploymentID(ctx context.Context, applicat
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to retrieve the current deployment ID for app '%s'", applicationID)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return "", getError(response)
-	}
 
 	var res struct {
 		Data struct {
@@ -381,13 +314,8 @@ func (d *deploymentService) GetCurrentDeploymentID(ctx context.Context, applicat
 		} `json:"data"`
 	}
 
-	err = readCloseResponseBody(response, &res)
-
-	if err != nil {
-		return "", errors.Wrap(err, "Unable to unmarshal content of the get deployment monitored request")
-	}
-
-	return res.Data.Deployment.ID, nil
+	err = processA4CResponse(response, &res, http.StatusOK)
+	return res.Data.Deployment.ID, errors.Wrap(err, "Unable to unmarshal content of the get deployment monitored request")
 
 }
 
@@ -404,22 +332,9 @@ func (d *deploymentService) GetNodeStatus(ctx context.Context, applicationID str
 	if err != nil {
 		return "", errors.Wrapf(err, "Cannot send a request to get node status of node '%s'", nodeName)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return "", getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return "", errors.Wrapf(err, "Cannot read the body of the node status for node '%s'", nodeName)
-	}
 
 	var nodeStatusResponse Informations
-
-	err = json.Unmarshal(responseBody, &nodeStatusResponse)
-
+	err = processA4CResponse(response, &nodeStatusResponse, http.StatusOK)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to unmarshal node status for node '%s'", nodeName)
 	}
@@ -451,27 +366,9 @@ func (d *deploymentService) GetOutputAttributes(ctx context.Context, application
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot send a request to get output properties")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Cannot read the body of the output properties")
-	}
-
 	var outputPropertiesResponse RuntimeTopology
-
-	err = json.Unmarshal(responseBody, &outputPropertiesResponse)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to unmarshal output properties")
-	}
-
-	return outputPropertiesResponse.Data.Topology.OutputAttributes, nil
+	err = processA4CResponse(response, &outputPropertiesResponse, http.StatusOK)
+	return outputPropertiesResponse.Data.Topology.OutputAttributes, errors.Wrap(err, "Unable to get output properties")
 
 }
 
@@ -488,24 +385,10 @@ func (d *deploymentService) GetAttributesValue(ctx context.Context, applicationI
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot send a request to get attributes value")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrapf(err, "Cannot read the body of the attributes value response '%s' in '%s' environment", applicationID, environmentID)
-	}
-
 	var nodeStatusResponse Informations
-
-	err = json.Unmarshal(responseBody, &nodeStatusResponse)
-
+	err = processA4CResponse(response, &nodeStatusResponse, http.StatusOK)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to unmarshal attributes value")
+		return nil, errors.Wrap(err, "Unable to get attributes value")
 	}
 
 	if len(nodeStatusResponse.Data) == 0 {
@@ -553,8 +436,7 @@ func (d *deploymentService) RunWorkflowAsync(ctx context.Context, a4cAppID strin
 	var res struct {
 		Data string `json:"data"`
 	}
-
-	err = readCloseResponseBody(response, &res)
+	err = processA4CResponse(response, &res, http.StatusOK)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read response on running workflow %q on application %q, environment %q", workflowName, a4cAppID, a4cEnvID)
 	}
@@ -641,17 +523,6 @@ func (d *deploymentService) GetLastWorkflowExecution(ctx context.Context, applic
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to get workflow status of application '%s'", applicationID)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Cannot read the response from Alien4Cloud")
-	}
 
 	var res struct {
 		Data struct {
@@ -659,12 +530,7 @@ func (d *deploymentService) GetLastWorkflowExecution(ctx context.Context, applic
 		} `json:"data"`
 	}
 
-	err = json.Unmarshal(responseBody, &res)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to unmarshal content of the execution status response")
-	}
-
-	return &res.Data.Execution, nil
+	err = processA4CResponse(response, &res, http.StatusOK)
+	return &res.Data.Execution, errors.Wrap(err, "Unable to get content of the execution status response")
 
 }

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -89,7 +89,7 @@ func (d *deploymentService) GetLocationsMatching(ctx context.Context, topologyID
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -166,7 +166,7 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	// Deploy the application a4cApplicationDeployhRequestIn
@@ -188,7 +188,7 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil
@@ -209,7 +209,7 @@ func (d *deploymentService) UpdateApplication(ctx context.Context, appID, envID 
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil
@@ -231,7 +231,7 @@ func (d *deploymentService) GetDeploymentList(ctx context.Context, appID string,
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -280,7 +280,7 @@ func (d *deploymentService) UndeployApplication(ctx context.Context, appID strin
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	return nil
@@ -333,7 +333,7 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	var statusResponse struct {
@@ -341,7 +341,7 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 		Error *Error `json:"error,omitempty"`
 	}
 
-	err = readBodyData(response, &statusResponse)
+	err = readCloseResponseBody(response, &statusResponse)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to unmarshal the deployment status")
 	}
@@ -370,7 +370,7 @@ func (d *deploymentService) GetCurrentDeploymentID(ctx context.Context, applicat
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	var res struct {
@@ -381,7 +381,7 @@ func (d *deploymentService) GetCurrentDeploymentID(ctx context.Context, applicat
 		} `json:"data"`
 	}
 
-	err = readBodyData(response, &res)
+	err = readCloseResponseBody(response, &res)
 
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to unmarshal content of the get deployment monitored request")
@@ -407,7 +407,7 @@ func (d *deploymentService) GetNodeStatus(ctx context.Context, applicationID str
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -454,7 +454,7 @@ func (d *deploymentService) GetOutputAttributes(ctx context.Context, application
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -491,7 +491,7 @@ func (d *deploymentService) GetAttributesValue(ctx context.Context, applicationI
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -554,7 +554,7 @@ func (d *deploymentService) RunWorkflowAsync(ctx context.Context, a4cAppID strin
 		Data string `json:"data"`
 	}
 
-	err = readBodyData(response, &res)
+	err = readCloseResponseBody(response, &res)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read response on running workflow %q on application %q, environment %q", workflowName, a4cAppID, a4cEnvID)
 	}
@@ -644,7 +644,7 @@ func (d *deploymentService) GetLastWorkflowExecution(ctx context.Context, applic
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -28,7 +28,7 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, FacetedSearchResult{}, getError(response.Body)
+		return nil, FacetedSearchResult{}, getError(response)
 	}
 
 	var res struct {
@@ -39,7 +39,7 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 		} `json:"data"`
 	}
 
-	err = readBodyData(response, &res)
+	err = readCloseResponseBody(response, &res)
 	if err != nil {
 		return nil, FacetedSearchResult{}, errors.Wrapf(err, "Cannot convert the body response to request on executions for deployment %q", deploymentID)
 	}

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -1,0 +1,47 @@
+package alien4cloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]WorkflowExecution, FacetedSearchResult, error) {
+	u := fmt.Sprintf("%s/executions/search?environmentId=%s&from=%s&size=%s", a4CRestAPIPrefix, deploymentID, url.QueryEscape(strconv.Itoa(from)), url.QueryEscape(strconv.Itoa(from)))
+	if query != "" {
+		u = fmt.Sprintf("%s&query=%s", u, url.QueryEscape(query))
+	}
+	response, err := d.client.doWithContext(ctx,
+		"GET",
+		u,
+		nil,
+		[]Header{acceptAppJSONHeader},
+	)
+
+	if err != nil {
+		return nil, FacetedSearchResult{}, errors.Wrapf(err, "Failed to get executions for deployment %q", deploymentID)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, FacetedSearchResult{}, getError(response.Body)
+	}
+
+	var res struct {
+		Data struct {
+			Types []string            `json:"types"`
+			Data  []WorkflowExecution `json:"data"`
+			FacetedSearchResult
+		} `json:"data"`
+	}
+
+	err = readBodyData(response, &res)
+	if err != nil {
+		return nil, FacetedSearchResult{}, errors.Wrapf(err, "Cannot convert the body response to request on executions for deployment %q", deploymentID)
+	}
+	return res.Data.Data, res.Data.FacetedSearchResult, nil
+}

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -11,7 +11,12 @@ import (
 )
 
 func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]WorkflowExecution, FacetedSearchResult, error) {
-	u := fmt.Sprintf("%s/executions/search?environmentId=%s&from=%s&size=%s", a4CRestAPIPrefix, deploymentID, url.QueryEscape(strconv.Itoa(from)), url.QueryEscape(strconv.Itoa(from)))
+	u := fmt.Sprintf("%s/executions/search?from=%s&size=%s", a4CRestAPIPrefix, url.QueryEscape(strconv.Itoa(from)), url.QueryEscape(strconv.Itoa(size)))
+
+	if deploymentID != "" {
+		u = fmt.Sprintf("%s&deploymentId=%s", u, url.QueryEscape(deploymentID))
+	}
+
 	if query != "" {
 		u = fmt.Sprintf("%s&query=%s", u, url.QueryEscape(query))
 	}

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -25,11 +25,6 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 	if err != nil {
 		return nil, FacetedSearchResult{}, errors.Wrapf(err, "Failed to get executions for deployment %q", deploymentID)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, FacetedSearchResult{}, getError(response)
-	}
 
 	var res struct {
 		Data struct {
@@ -39,9 +34,6 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 		} `json:"data"`
 	}
 
-	err = readCloseResponseBody(response, &res)
-	if err != nil {
-		return nil, FacetedSearchResult{}, errors.Wrapf(err, "Cannot convert the body response to request on executions for deployment %q", deploymentID)
-	}
-	return res.Data.Data, res.Data.FacetedSearchResult, nil
+	err = processA4CResponse(response, &res, http.StatusOK)
+	return res.Data.Data, res.Data.FacetedSearchResult, errors.Wrapf(err, "Cannot convert the body response to request on executions for deployment %q", deploymentID)
 }

--- a/alien4cloud/deployment_execution_test.go
+++ b/alien4cloud/deployment_execution_test.go
@@ -14,11 +14,11 @@ func Test_deploymentService_GetExecutions(t *testing.T) {
 	closeCh := make(chan struct{})
 	defer close(closeCh)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Assert(t, "" != r.URL.Query().Get("environmentId"))
+		assert.Assert(t, "" != r.URL.Query().Get("deploymentId"))
 		assert.Assert(t, "" != r.URL.Query().Get("from"))
 		assert.Assert(t, "" != r.URL.Query().Get("size"))
 
-		switch r.URL.Query().Get("environmentId") {
+		switch r.URL.Query().Get("deploymentId") {
 		case "normal":
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))

--- a/alien4cloud/deployment_execution_test.go
+++ b/alien4cloud/deployment_execution_test.go
@@ -1,0 +1,92 @@
+package alien4cloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_deploymentService_GetExecutions(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Assert(t, "" != r.URL.Query().Get("environmentId"))
+		assert.Assert(t, "" != r.URL.Query().Get("from"))
+		assert.Assert(t, "" != r.URL.Query().Get("size"))
+
+		switch r.URL.Query().Get("environmentId") {
+		case "normal":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			return
+		case "query":
+			assert.Assert(t, "" != r.URL.Query().Get("query"))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":1,"from":0,"to":0,"facets":null},"error":null}`))
+			return
+		case "multi":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{"types":["execution","execution","execution"],"data":[{"id":"d9f63781-5245-4cd0-a24c-b83d4c4842f1","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"startWebServer","workflowName":"startWebServer","displayWorkflowName":"startWebServer","startDate":1578951354540,"endDate":1578951378035,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"e8cbb5bd-5f85-408e-9190-caee179d0581","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"install","workflowName":"install","displayWorkflowName":"install","startDate":1578933372461,"endDate":1578933443757,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":0,"to":2,"facets":null},"error":null}`))
+			return
+		case "error":
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			return
+		}
+	}))
+
+	type args struct {
+		ctx          context.Context
+		deploymentID string
+		query        string
+		from         int
+		size         int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []WorkflowExecution
+		want1   FacetedSearchResult
+		wantErr bool
+	}{
+		{"normal", args{context.Background(), "normal", "", 1, 1},
+			[]WorkflowExecution{
+				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+			},
+			FacetedSearchResult{TotalResults: 3, From: 1, To: 1},
+			false,
+		},
+		{"query", args{context.Background(), "query", "7459ca00-f98f-47f1-a7e8-4d779d65253a", 0, 1},
+			[]WorkflowExecution{
+				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+			},
+			FacetedSearchResult{TotalResults: 1, From: 0, To: 0},
+			false,
+		},
+		{"multi", args{context.Background(), "multi", "", 0, 10},
+			[]WorkflowExecution{
+				WorkflowExecution{ID: "d9f63781-5245-4cd0-a24c-b83d4c4842f1", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "startWebServer", WorkflowName: "startWebServer", DisplayWorkflowName: "startWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+				WorkflowExecution{ID: "e8cbb5bd-5f85-408e-9190-caee179d0581", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "install", WorkflowName: "install", DisplayWorkflowName: "install", Status: "SUCCEEDED", HasFailedTasks: false},
+			},
+			FacetedSearchResult{TotalResults: 3, From: 0, To: 2},
+			false,
+		},
+		{"error", args{context.Background(), "error", "", 0, 10}, nil, FacetedSearchResult{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &deploymentService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			got, got1, err := d.GetExecutions(tt.args.ctx, tt.args.deploymentID, tt.args.query, tt.args.from, tt.args.size)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deploymentService.GetExecutions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.DeepEqual(t, got, tt.want)
+			assert.DeepEqual(t, got1, tt.want1)
+		})
+	}
+}

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -105,7 +105,7 @@ func Test_deploymentService_WaitUntilStateIs(t *testing.T) {
 			return
 		case regexp.MustCompile(`.*/deployments/.*/status`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":"deployed"}`))
+			w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, ApplicationDeployed)))
 			return
 
 		}
@@ -180,33 +180,19 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 			w.Write([]byte(`{"data":`))
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/workflows/.*`).Match([]byte(r.URL.Path)):
+			matches := regexp.MustCompile(`.*/applications/(.*)/environments/.*/workflows/.*`).FindStringSubmatch(r.URL.Path)
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":"execID"}`))
+			w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, matches[1])))
 			return
-		case regexp.MustCompile(`.*/applications/badDepID/environments/.*/active-deployment-monitored`).Match([]byte(r.URL.Path)):
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"deployment":`))
-			return
-
-		case regexp.MustCompile(`.*/applications/execCancel/environments/.*/active-deployment-monitored`).Match([]byte(r.URL.Path)):
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"deployment":{"id":"execCancel"}}}`))
-			return
-
-		case regexp.MustCompile(`.*/applications/.*/environments/.*/active-deployment-monitored`).Match([]byte(r.URL.Path)):
-			matches := regexp.MustCompile(`.*/applications/(.*)/environments/.*/active-deployment-monitored`).FindStringSubmatch(r.URL.Path)
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(fmt.Sprintf(`{"data":{"deployment":{"id":"%s"}}}`, matches[1])))
-			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("environmentId") == "execCancel":
+		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "execCancel":
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"RUNNING","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
 			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("environmentId") == "badExecSearch":
+		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "badExecSearch":
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"i`))
 			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("environmentId") == "noExecSearch":
+		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "noExecSearch":
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"data":{"types":[],"data":[],"queryDuration":1,"totalResults":0,"from":0,"to":0,"facets":null},"error":null}`))
 			return
@@ -239,7 +225,6 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 		},
 		{"EmptyExecID", args{context.Background(), "emptyExecID", "env", "wf", 5 * time.Minute}, nil, true},
 		{"BadExecID", args{context.Background(), "badExecID", "env", "wf", 5 * time.Minute}, nil, true},
-		{"BadDepID", args{context.Background(), "badDepID", "env", "wf", 5 * time.Minute}, nil, true},
 		{"BadExecSearch", args{context.Background(), "badExecSearch", "env", "wf", 5 * time.Minute}, nil, true},
 		{"NoExecSearch", args{context.Background(), "noExecSearch", "env", "wf", 5 * time.Minute}, nil, true},
 	}

--- a/alien4cloud/log.go
+++ b/alien4cloud/log.go
@@ -79,7 +79,7 @@ func (l *logService) GetLogsOfApplication(ctx context.Context, applicationID str
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, 0, getError(response.Body)
+		return nil, 0, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -137,7 +137,7 @@ func (l *logService) GetLogsOfApplication(ctx context.Context, applicationID str
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, 0, getError(response.Body)
+		return nil, 0, getError(response)
 	}
 
 	responseBody, err = ioutil.ReadAll(response.Body)

--- a/alien4cloud/orchestrator.go
+++ b/alien4cloud/orchestrator.go
@@ -52,7 +52,7 @@ func (o *orchestratorService) GetOrchestratorLocations(ctx context.Context, orch
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -108,7 +108,7 @@ func (o *orchestratorService) GetOrchestratorIDbyName(ctx context.Context, orche
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)

--- a/alien4cloud/orchestrator.go
+++ b/alien4cloud/orchestrator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -49,17 +48,6 @@ func (o *orchestratorService) GetOrchestratorLocations(ctx context.Context, orch
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to send request to get orchestrator location for orchestrator '%s'", orchestratorID)
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to read the content of orchestrator locations request for orchestrator '%s'", orchestratorID)
-	}
 
 	var loc Location
 	var locationstoreturn []Location
@@ -72,7 +60,8 @@ func (o *orchestratorService) GetOrchestratorLocations(ctx context.Context, orch
 			} `json:"location"`
 		} `json:"data"`
 	}
-	if err = json.Unmarshal([]byte(responseBody), &res); err != nil {
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
 		return nil, errors.Wrapf(err, "Cannot convert the body of the get '%s' orchestrator location", orchestratorID)
 	}
 
@@ -105,17 +94,6 @@ func (o *orchestratorService) GetOrchestratorIDbyName(ctx context.Context, orche
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to send request to get orchestrator ID from its name")
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return "", getError(response)
-	}
-
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return "", errors.Wrapf(err, "Cannot read the body of the search for '%s' orchestrator", orchestratorName)
-	}
 
 	var res struct {
 		Data struct {
@@ -127,17 +105,17 @@ func (o *orchestratorService) GetOrchestratorIDbyName(ctx context.Context, orche
 		} `json:"data"`
 	}
 
-	if err = json.Unmarshal([]byte(responseBody), &res); err != nil {
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
 		return "", errors.Wrapf(err, "Cannot convert the body of the search for '%s' orchestrator", orchestratorName)
 	}
 	if res.Data.TotalResults <= 0 {
-		return "", fmt.Errorf("'%s' orchestrator name does not exist", orchestratorName)
+		return "", errors.Errorf("'%s' orchestrator name does not exist", orchestratorName)
 	}
 
 	orchestratorID := res.Data.Data[0].ID
 	if orchestratorID == "" {
-		return orchestratorID, fmt.Errorf("no ID for '%s' orchestrator", orchestratorName)
+		return orchestratorID, errors.Errorf("no ID for '%s' orchestrator", orchestratorName)
 	}
 	return orchestratorID, nil
-
 }

--- a/alien4cloud/topology.go
+++ b/alien4cloud/topology.go
@@ -97,8 +97,6 @@ func (t *topologyService) GetTopologyID(ctx context.Context, appID string, envID
 		return "", getError(response.Body)
 	}
 
-	responseBody, err := ioutil.ReadAll(response.Body)
-
 	if err != nil {
 		return "", errors.Wrapf(err, "Cannot read the body of the topology get data for application '%s' in '%s' environment", appID, envID)
 	}
@@ -106,7 +104,8 @@ func (t *topologyService) GetTopologyID(ctx context.Context, appID string, envID
 		Data string `json:"data"`
 	}
 
-	if err = json.Unmarshal([]byte(responseBody), &res); err != nil {
+	err = readBodyData(response, &res)
+	if err != nil {
 		return "", errors.Wrapf(err, "Cannot convert the body of topology get data for application '%s' in '%s' environment", appID, envID)
 	}
 
@@ -204,11 +203,6 @@ func (t *topologyService) editTopology(ctx context.Context, a4cCtx *TopologyEdit
 	if response.StatusCode != http.StatusOK {
 		return getError(response.Body)
 	}
-	responseBody, err := ioutil.ReadAll(response.Body)
-
-	if err != nil {
-		return errors.Wrap(err, "Unable to read the content of a topology edition request")
-	}
 
 	var resExec struct {
 		Data struct {
@@ -218,8 +212,8 @@ func (t *topologyService) editTopology(ctx context.Context, a4cCtx *TopologyEdit
 			} `json:"operations"`
 		} `json:"data"`
 	}
-
-	if err = json.Unmarshal([]byte(responseBody), &resExec); err != nil {
+	err = readBodyData(response, &resExec)
+	if err != nil {
 		return errors.Wrap(err, "Unable to unmarshal a topology edition response")
 	}
 

--- a/alien4cloud/topology.go
+++ b/alien4cloud/topology.go
@@ -94,7 +94,7 @@ func (t *topologyService) GetTopologyID(ctx context.Context, appID string, envID
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	if err != nil {
@@ -104,7 +104,7 @@ func (t *topologyService) GetTopologyID(ctx context.Context, appID string, envID
 		Data string `json:"data"`
 	}
 
-	err = readBodyData(response, &res)
+	err = readCloseResponseBody(response, &res)
 	if err != nil {
 		return "", errors.Wrapf(err, "Cannot convert the body of topology get data for application '%s' in '%s' environment", appID, envID)
 	}
@@ -134,7 +134,7 @@ func (t *topologyService) GetTopologyTemplateIDByName(ctx context.Context, topol
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", getError(response.Body)
+		return "", getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -201,7 +201,7 @@ func (t *topologyService) editTopology(ctx context.Context, a4cCtx *TopologyEdit
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	var resExec struct {
@@ -212,7 +212,7 @@ func (t *topologyService) editTopology(ctx context.Context, a4cCtx *TopologyEdit
 			} `json:"operations"`
 		} `json:"data"`
 	}
-	err = readBodyData(response, &resExec)
+	err = readCloseResponseBody(response, &resExec)
 	if err != nil {
 		return errors.Wrap(err, "Unable to unmarshal a topology edition response")
 	}
@@ -247,7 +247,7 @@ func (t *topologyService) getTopology(ctx context.Context, appID string, envID s
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, getError(response.Body)
+		return nil, getError(response)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
@@ -567,7 +567,7 @@ func (t *topologyService) SaveA4CTopology(ctx context.Context, a4cCtx *TopologyE
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return getError(response.Body)
+		return getError(response)
 	}
 
 	// After saving topology, get come back to a clear state.

--- a/alien4cloud/utils.go
+++ b/alien4cloud/utils.go
@@ -16,7 +16,6 @@ package alien4cloud
 
 import (
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -25,18 +24,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getError(body io.ReadCloser) error {
-
-	r, _ := ioutil.ReadAll(body)
-	body.Close()
-
+func getError(response *http.Response) error {
 	var res struct {
 		Error Error `json:"error"`
 	}
+	err := readCloseResponseBody(response, &res)
 
-	err := json.Unmarshal(r, &res)
 	if err != nil {
-		return errors.New("failed to read error message from Alien4Cloud")
+		return err
 	}
 
 	return errors.New(res.Error.Message)
@@ -75,7 +70,7 @@ func (jar *jar) Cookies(u *url.URL) []*http.Cookie {
 	return jar.cookies[u.Host]
 }
 
-func readBodyData(response *http.Response, data interface{}) error {
+func readCloseResponseBody(response *http.Response, data interface{}) error {
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/alien4cloud/utils.go
+++ b/alien4cloud/utils.go
@@ -74,3 +74,13 @@ func (jar *jar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 func (jar *jar) Cookies(u *url.URL) []*http.Cookie {
 	return jar.cookies[u.Host]
 }
+
+func readBodyData(response *http.Response, data interface{}) error {
+	defer response.Body.Close()
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot read the response from Alien4Cloud")
+	}
+	err = json.Unmarshal(responseBody, &data)
+	return errors.Wrap(err, "Unable to unmarshal content of the execution status response")
+}

--- a/examples/upload-csar/main.go
+++ b/examples/upload-csar/main.go
@@ -41,13 +41,14 @@ func main() {
 		log.Panic(err)
 	}
 
-	err = client.Login()
+	// Can use context for cancelation
+	ctx := context.Background()
+
+	err = client.Login(ctx)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	// Can use context for cancelation
-	ctx := context.Background()
 	csarDef, err := client.CatalogService().UploadCSAR(ctx, f, workspace)
 	if err != nil {
 		var pErr alien4cloud.ParsingErr


### PR DESCRIPTION
Run workflows make use of `GetExecutions` instead of `GetLastWorkflowExecution` that can't work with multi workflows.

Also added an asynchronous version of RunWorkflow.

