### PR TITLE
Add functions to update application input properties and artifacts

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -303,7 +303,7 @@ type EntrySchema struct {
 	Description string `json:"description,omitempty"`
 }
 
-// PropertyDefinition holds the definition of a Topology property
+// PropertyDefinition holds the definition of a Topology input property
 type PropertyDefinition struct {
 	Type         string        `json:"type"`
 	EntrySchema  EntrySchema   `json:"entrySchema,omitempty"`
@@ -312,6 +312,21 @@ type PropertyDefinition struct {
 	Description  string        `json:"description,omitempty"`
 	SuggestionId string        `json:"suggestionId,omitempty"`
 	Password     bool          `json:"password,omitempty"`
+}
+
+// DeploymentArtifact holds properties of an artifact (file) input definition in topology
+type DeploymentArtifact struct {
+	ArtifactType         string                 `json:"artifactType"`
+	ArtifactRef          string                 `json:"artifactRef,omitempty"`
+	ArtifactRepository   string                 `json:"artifactRepository,omitempty"`
+	ArchiveName          string                 `json:"archiveName,omitempty"`
+	ArchiveVersion       string                 `json:"archiveVersion,omitempty"`
+	RepositoryURL        string                 `json:"repositoryURL,omitempty"`
+	RepositoryCredential map[string]interface{} `json:"repositoryCredential,omitempty"`
+	RepositoryName       string                 `json:"repositoryName,omitempty"`
+	ArtifactName         string                 `json:"artifactName,omitempty"`
+	DeployPath           string                 `json:"deployPath,omitempty"`
+	Description          string                 `json:"description,omitempty"`
 }
 
 // Topology is the representation a topology template
@@ -324,9 +339,17 @@ type Topology struct {
 			ArchiveName    string                        `json:"archiveName"`
 			ArchiveVersion string                        `json:"archiveVersion"`
 			NodeTemplates  map[string]nodeTemplate       `json:"nodeTemplates"`
-			Inputs         map[string]PropertyDefinition `json:"inputs"`
+			Inputs         map[string]PropertyDefinition `json:"inputs,omitempty"`
+			InputArtifacts map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
 		} `json:"topology"`
 	} `json:"data"`
+}
+
+// UpdateDeploymentTopologyRequest holds a request to update inputs of a deployment
+// topology
+type UpdateDeploymentTopologyRequest struct {
+	InputProperties              map[string]interface{} `json:"inputProperties,omitempty"`
+	ProviderDeploymentProperties map[string]string      `json:"providerDeploymentProperties,omitempty"`
 }
 
 // ApplicationCreateRequest is the representation of a request to create an application from a topology template

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -291,6 +291,29 @@ type Deployment struct {
 	WorkflowExecutions       interface{} `json:"workflowExecutions"`
 }
 
+// PropertyValue holds the definition of a property value
+type PropertyValue struct {
+	Value      interface{} `json:"value"`
+	Definition bool        `json:"definition,omitempty"`
+}
+
+// Definition of the type of an element in a list
+type EntrySchema struct {
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+// PropertyDefinition holds the definition of a Topology property
+type PropertyDefinition struct {
+	Type         string        `json:"type"`
+	EntrySchema  EntrySchema   `json:"entrySchema,omitempty"`
+	Required     bool          `json:"required,omitempty"`
+	DefaultValue PropertyValue `json:"defaultValue,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	SuggestionId string        `json:"suggestionId,omitempty"`
+	Password     bool          `json:"password,omitempty"`
+}
+
 // Topology is the representation a topology template
 type Topology struct {
 	Data struct {
@@ -298,9 +321,10 @@ type Topology struct {
 		RelationshipTypes map[string]relationshipType `json:"relationshipTypes"`
 		CapabilityTypes   map[string]capabilityType   `json:"capabilityTypes"`
 		Topology          struct {
-			ArchiveName    string                  `json:"archiveName"`
-			ArchiveVersion string                  `json:"archiveVersion"`
-			NodeTemplates  map[string]nodeTemplate `json:"nodeTemplates"`
+			ArchiveName    string                        `json:"archiveName"`
+			ArchiveVersion string                        `json:"archiveVersion"`
+			NodeTemplates  map[string]nodeTemplate       `json:"nodeTemplates"`
+			Inputs         map[string]PropertyDefinition `json:"inputs"`
 		} `json:"topology"`
 	} `json:"data"`
 }

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -297,7 +297,7 @@ type PropertyValue struct {
 	Definition bool        `json:"definition,omitempty"`
 }
 
-// Definition of the type of an element in a list
+// EntrySchema holds the definition of the type of an element in a list
 type EntrySchema struct {
 	Type        string `json:"type"`
 	Description string `json:"description,omitempty"`
@@ -310,7 +310,7 @@ type PropertyDefinition struct {
 	Required     bool          `json:"required,omitempty"`
 	DefaultValue PropertyValue `json:"defaultValue,omitempty"`
 	Description  string        `json:"description,omitempty"`
-	SuggestionId string        `json:"suggestionId,omitempty"`
+	SuggestionID string        `json:"suggestionId,omitempty"`
 	Password     bool          `json:"password,omitempty"`
 }
 

--- a/alien4cloud/application.go
+++ b/alien4cloud/application.go
@@ -156,7 +156,7 @@ func (a *applicationService) IsApplicationExist(ctx context.Context, application
 
 	case http.StatusNotFound:
 		// to fully read response
-		processA4CResponse(response, nil, http.StatusNotFound)
+		_ = processA4CResponse(response, nil, http.StatusNotFound)
 		return false, nil
 
 	default:
@@ -197,7 +197,7 @@ func (a *applicationService) GetApplicationsID(ctx context.Context, filter strin
 	case http.StatusNotFound:
 		// No application with this filter have been found
 		// to fully read response
-		processA4CResponse(response, nil, http.StatusNotFound)
+		_ = processA4CResponse(response, nil, http.StatusNotFound)
 		return nil, nil
 
 	default:
@@ -262,7 +262,7 @@ func (a *applicationService) GetApplicationByID(ctx context.Context, id string) 
 	case http.StatusNotFound:
 		// No application with this filter have been found
 		// to fully read response
-		processA4CResponse(response, nil, http.StatusNotFound)
+		_ = processA4CResponse(response, nil, http.StatusNotFound)
 		return nil, nil
 
 	default:

--- a/alien4cloud/application_test.go
+++ b/alien4cloud/application_test.go
@@ -44,6 +44,8 @@ func Test_applicationService_IsApplicationExists(t *testing.T) {
 		t.Errorf("Unexpected call for request %+v", r)
 	}))
 
+	defer ts.Close()
+
 	type args struct {
 		ctx   context.Context
 		appID string
@@ -73,7 +75,8 @@ func Test_applicationService_IsApplicationExists(t *testing.T) {
 }
 
 func Test_applicationService_GetApplicationsID(t *testing.T) {
-	ts := getHTTPServerTestApplicationSearch(t)
+	ts := newHTTPServerTestApplicationSearch(t)
+	defer ts.Close()
 	type args struct {
 		ctx   context.Context
 		appID string
@@ -103,7 +106,8 @@ func Test_applicationService_GetApplicationsID(t *testing.T) {
 }
 
 func Test_applicationService_GetApplicationByID(t *testing.T) {
-	ts := getHTTPServerTestApplicationSearch(t)
+	ts := newHTTPServerTestApplicationSearch(t)
+	defer ts.Close()
 	type args struct {
 		ctx   context.Context
 		appID string
@@ -132,7 +136,7 @@ func Test_applicationService_GetApplicationByID(t *testing.T) {
 	}
 }
 
-func getHTTPServerTestApplicationSearch(t *testing.T) *httptest.Server {
+func newHTTPServerTestApplicationSearch(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if regexp.MustCompile(`.*/applications`).Match([]byte(r.URL.Path)) {
 

--- a/alien4cloud/application_test.go
+++ b/alien4cloud/application_test.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_applicationService_IsApplicationExists(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/applications/unknown`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			return
+		case regexp.MustCompile(`.*/applications/existing`).Match([]byte(r.URL.Path)):
+			// wait until test are finish to simulate long running op that will be cancelled
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":""}`))
+			return
+		}
+
+		// Should not go there
+		t.Errorf("Unexpected call for request %+v", r)
+	}))
+
+	type args struct {
+		ctx   context.Context
+		appID string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		exists bool
+	}{
+		{"ExistingApp", args{context.Background(), "existing"}, true},
+		{"UnknownApp", args{context.Background(), "unknown"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			a := &applicationService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+
+			found, err := a.IsApplicationExist(tt.args.ctx, tt.args.appID)
+			if err != nil {
+				t.Errorf("applicationService.IsApplicationExist() error = %v", err)
+			}
+			assert.Equal(t, tt.exists, found, "Unexpected result for IsApplicationExist %s", tt.args.appID)
+		})
+	}
+}

--- a/alien4cloud/catalog_test.go
+++ b/alien4cloud/catalog_test.go
@@ -58,7 +58,11 @@ func Test_catalogService_UploadCSAR(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write(b)
+		_, err = w.Write(b)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -205,10 +205,7 @@ func (d *deploymentService) UpdateApplication(ctx context.Context, appID, envID 
 func (d *deploymentService) UpdateDeploymentSetup(ctx context.Context, appID, envID string,
 	request UpdateDeploymentTopologyRequest) error {
 
-	requestBody, err := json.Marshal(request)
-	if err != nil {
-		return errors.Wrap(err, "Failed to marshal update deployment topology request")
-	}
+	requestBody, _ := json.Marshal(request)
 	response, err := d.client.doWithContext(ctx, "PUT",
 		fmt.Sprintf("%s/applications/%s/environments/%s/deployment-topology", a4CRestAPIPrefix, appID, envID),
 		[]byte(string(requestBody)),

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -159,6 +159,10 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 			appID,
 		},
 	)
+	if err != nil {
+		return errors.Wrap(err, "Failed to marshal application deployment request")
+	}
+
 	response, err = d.client.doWithContext(ctx,
 		"POST",
 		fmt.Sprintf("%s/applications/deployment", a4CRestAPIPrefix),

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -39,7 +39,7 @@ type DeploymentService interface {
 	// Updates an application with the latest topology version
 	UpdateApplication(ctx context.Context, appID, envID string) error
 	// Updates inputs of a deployment topology
-	UpdateDeploymentSetup(ctx context.Context, appID, envID string, request UpdateDeploymentTopologyRequest) error
+	UpdateDeploymentTopology(ctx context.Context, appID, envID string, request UpdateDeploymentTopologyRequest) error
 	// Uploads an input artifact
 	UploadDeploymentInputArtifact(ctx context.Context, appID, envID, inputArtifact, filePath string) error
 	// Returns the deployment list for the given appID and envID
@@ -201,8 +201,8 @@ func (d *deploymentService) UpdateApplication(ctx context.Context, appID, envID 
 	return processA4CResponse(response, nil, http.StatusOK)
 }
 
-// UpdateDeploymentSetup updates inputs of a deployment topology
-func (d *deploymentService) UpdateDeploymentSetup(ctx context.Context, appID, envID string,
+// UpdateDeploymentTopology updates inputs of a deployment topology
+func (d *deploymentService) UpdateDeploymentTopology(ctx context.Context, appID, envID string,
 	request UpdateDeploymentTopologyRequest) error {
 
 	requestBody, _ := json.Marshal(request)

--- a/alien4cloud/deployment_execution_test.go
+++ b/alien4cloud/deployment_execution_test.go
@@ -21,20 +21,20 @@ func Test_deploymentService_GetExecutions(t *testing.T) {
 		switch r.URL.Query().Get("deploymentId") {
 		case "normal":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
 			return
 		case "query":
 			assert.Assert(t, "" != r.URL.Query().Get("query"))
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":1,"from":0,"to":0,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":1,"from":0,"to":0,"facets":null},"error":null}`))
 			return
 		case "multi":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution","execution","execution"],"data":[{"id":"d9f63781-5245-4cd0-a24c-b83d4c4842f1","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"startWebServer","workflowName":"startWebServer","displayWorkflowName":"startWebServer","startDate":1578951354540,"endDate":1578951378035,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"e8cbb5bd-5f85-408e-9190-caee179d0581","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"install","workflowName":"install","displayWorkflowName":"install","startDate":1578933372461,"endDate":1578933443757,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":0,"to":2,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution","execution","execution"],"data":[{"id":"d9f63781-5245-4cd0-a24c-b83d4c4842f1","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"startWebServer","workflowName":"startWebServer","displayWorkflowName":"startWebServer","startDate":1578951354540,"endDate":1578951378035,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false},{"id":"e8cbb5bd-5f85-408e-9190-caee179d0581","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"install","workflowName":"install","displayWorkflowName":"install","startDate":1578933372461,"endDate":1578933443757,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":0,"to":2,"facets":null},"error":null}`))
 			return
 		case "error":
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
 			return
 		case "internalerror":
 			<-closeCh

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -93,19 +93,19 @@ func Test_deploymentService_WaitUntilStateIs(t *testing.T) {
 		switch {
 		case regexp.MustCompile(`.*/applications/err/environments/.*/active-deployment-monitored`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"deployment":{"id":"err"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":"err"}}}`))
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/active-deployment-monitored`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"deployment":{"id":"myID"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":"myID"}}}`))
 			return
 		case regexp.MustCompile(`.*/deployments/err/status`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
 			return
 		case regexp.MustCompile(`.*/deployments/.*/status`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, ApplicationDeployed)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, ApplicationDeployed)))
 			return
 
 		}
@@ -173,32 +173,32 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 			return
 		case regexp.MustCompile(`.*/applications/emptyExecID/environments/.*/workflows/.*`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":""}`))
+			_, _ = w.Write([]byte(`{"data":""}`))
 			return
 		case regexp.MustCompile(`.*/applications/badExecID/environments/.*/workflows/.*`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":`))
+			_, _ = w.Write([]byte(`{"data":`))
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/workflows/.*`).Match([]byte(r.URL.Path)):
 			matches := regexp.MustCompile(`.*/applications/(.*)/environments/.*/workflows/.*`).FindStringSubmatch(r.URL.Path)
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, matches[1])))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, matches[1])))
 			return
 		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "execCancel":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"RUNNING","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"RUNNING","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
 			return
 		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "badExecSearch":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"i`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"i`))
 			return
 		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "noExecSearch":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":[],"data":[],"queryDuration":1,"totalResults":0,"from":0,"to":0,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":[],"data":[],"queryDuration":1,"totalResults":0,"from":0,"to":0,"facets":null},"error":null}`))
 			return
 		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
 			return
 		}
 

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -272,8 +272,6 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 }
 
 func Test_deploymentService_UpdateDeploymentSetup(t *testing.T) {
-	closeCh := make(chan struct{})
-	defer close(closeCh)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case regexp.MustCompile(`.*/applications/error/environments/.*/deployment-topology`).Match([]byte(r.URL.Path)):
@@ -340,8 +338,6 @@ func Test_deploymentService_UpdateDeploymentSetup(t *testing.T) {
 }
 
 func Test_deploymentService_UploadDeploymentInputArtifact(t *testing.T) {
-	closeCh := make(chan struct{})
-	defer close(closeCh)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case regexp.MustCompile(`.*/applications/error/environments/.*/deployment-topology/inputArtifacts/.*/upload`).Match([]byte(r.URL.Path)):
@@ -391,11 +387,12 @@ func Test_deploymentService_UploadDeploymentInputArtifact(t *testing.T) {
 			}
 
 			f, err := ioutil.TempFile("", "test"+tt.name)
+			assert.NilError(t, err, "Failed to create a file to upload")
 			_, err = f.Write([]byte(tt.args.content))
 			_ = f.Sync()
 			_ = f.Close()
 			defer os.Remove(f.Name())
-			assert.NilError(t, err, "Failed to create a file to upload")
+			assert.NilError(t, err, "Failed to write to file to upload")
 
 			err = d.UploadDeploymentInputArtifact(tt.args.ctx, tt.args.appID, tt.args.envID, tt.args.inputArtifactName, f.Name())
 			if err != nil && !tt.wantErr {

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -301,6 +301,8 @@ func Test_deploymentService_UpdateDeploymentSetup(t *testing.T) {
 		t.Errorf("Unexpected call for request %+v", r)
 	}))
 
+	defer ts.Close()
+
 	type args struct {
 		ctx                context.Context
 		appID              string
@@ -363,6 +365,8 @@ func Test_deploymentService_UploadDeploymentInputArtifact(t *testing.T) {
 		// Should not go there
 		t.Errorf("Unexpected call for request %+v", r)
 	}))
+
+	defer ts.Close()
 
 	type args struct {
 		ctx               context.Context

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -325,14 +325,14 @@ func Test_deploymentService_UpdateDeploymentSetup(t *testing.T) {
 				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
 			}
 
-			err := d.UpdateDeploymentSetup(tt.args.ctx, tt.args.appID, tt.args.envID,
+			err := d.UpdateDeploymentTopology(tt.args.ctx, tt.args.appID, tt.args.envID,
 				UpdateDeploymentTopologyRequest{
 					InputProperties: map[string]interface{}{
 						tt.args.inputPropertyName: tt.args.inputPropertyValue,
 					},
 				})
 			if err != nil && !tt.wantErr {
-				t.Errorf("deploymentService.UpdateDeploymentSetup() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("deploymentService.UpdateDeploymentTopology() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -411,7 +411,7 @@ func Test_deploymentService_UploadDeploymentInputArtifact(t *testing.T) {
 			err = d.UploadDeploymentInputArtifact(tt.args.ctx, tt.args.appID, tt.args.envID,
 				tt.args.inputArtifactName, artifactPath)
 			if err != nil && !tt.wantErr {
-				t.Errorf("deploymentService.UpdateDeploymentSetup() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("deploymentService.UpdateDeploymentTopology() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/alien4cloud/topology.go
+++ b/alien4cloud/topology.go
@@ -31,6 +31,8 @@ type TopologyService interface {
 	GetTopologyID(ctx context.Context, appID string, envID string) (string, error)
 	// Returns the topology template ID for the given topologyName
 	GetTopologyTemplateIDByName(ctx context.Context, topologyName string) (string, error)
+	// Returns Topology details for a given application and environment
+	GetTopology(ctx context.Context, appID string, envID string) (*Topology, error)
 	// Updates the property value (type string) of a component of an application
 	UpdateComponentProperty(ctx context.Context, a4cCtx *TopologyEditorContext, componentName string, propertyName string, propertyValue string) error
 	// Updates the property value (type tosca complex) of a component of an application
@@ -180,8 +182,8 @@ func (t *topologyService) editTopology(ctx context.Context, a4cCtx *TopologyEdit
 	return nil
 }
 
-// getTopology method returns the A4C topology on a given application and environment
-func (t *topologyService) getTopology(ctx context.Context, appID string, envID string) (*Topology, error) {
+// GetTopology method returns topology details for a given application and environment
+func (t *topologyService) GetTopology(ctx context.Context, appID string, envID string) (*Topology, error) {
 
 	a4cTopologyID, err := t.GetTopologyID(ctx, appID, envID)
 
@@ -324,7 +326,7 @@ func (t *topologyService) AddNodeInA4CTopology(ctx context.Context, a4cCtx *Topo
 		return errors.New("Context object must be defined")
 	}
 
-	a4cTopology, err := t.getTopology(ctx, a4cCtx.AppID, a4cCtx.EnvID)
+	a4cTopology, err := t.GetTopology(ctx, a4cCtx.AppID, a4cCtx.EnvID)
 
 	if err != nil {
 		return errors.Wrapf(err, "Unable to get A4C application topology for app %s and env %s", a4cCtx.AppID, a4cCtx.EnvID)
@@ -382,7 +384,7 @@ func (t *topologyService) AddRelationship(ctx context.Context, a4cCtx *TopologyE
 	var relationshipDef relationshipType
 	var capabilityDef componentCapability
 
-	a4cTopology, err := t.getTopology(ctx, a4cCtx.AppID, a4cCtx.EnvID)
+	a4cTopology, err := t.GetTopology(ctx, a4cCtx.AppID, a4cCtx.EnvID)
 
 	if err != nil {
 		return errors.Wrapf(err, "Unable to get A4C application topology for app %s and env %s", a4cCtx.AppID, a4cCtx.EnvID)

--- a/alien4cloud/topology.go
+++ b/alien4cloud/topology.go
@@ -63,18 +63,6 @@ type topologyService struct {
 const (
 	// a4cUpdateNodePropertyValueOperationJavaClassName a4c class name to update node property value operation
 	a4cUpdateNodePropertyValueOperationJavaClassName = "org.alien4cloud.tosca.editor.operations.nodetemplate.UpdateNodePropertyValueOperation"
-
-	// a4cUpdateNodePropertyValueSlurmJobOptions yorc struct name for slurm JobOptions
-	a4cUpdateNodePropertyValueSlurmJobOptions = "yorc.datatypes.slurm.JobOptions"
-
-	// a4cUpdateCapabilityPropertyValueOperationJavaClassName a4c class name to update capability value operation
-	a4cUpdateCapabilityPropertyValueOperationJavaClassName = "org.alien4cloud.tosca.editor.operations.nodetemplate.UpdateCapabilityPropertyValueOperation"
-
-	// a4cAddNodeOperationJavaClassName a4c class name to add node operation
-	a4cAddNodeOperationJavaClassName = "org.alien4cloud.tosca.editor.operations.nodetemplate.AddNodeOperation"
-
-	// a4cAddRelationshipOperationJavaClassName a4c class name to add relationship operation
-	a4cAddRelationshipOperationJavaClassName = "org.alien4cloud.tosca.editor.operations.relationshiptemplate.AddRelationshipOperation"
 )
 
 // GetTopologyID returns the A4C topology ID on a given application and environment

--- a/alien4cloud/topology_policies_test.go
+++ b/alien4cloud/topology_policies_test.go
@@ -61,11 +61,11 @@ func Test_topologyService_AddPolicy(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		case regexp.MustCompile(`.*/applications/notfound/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			var res struct {
@@ -78,7 +78,7 @@ func Test_topologyService_AddPolicy(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		}
 
@@ -161,11 +161,11 @@ func Test_topologyService_DeletePolicy(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		case regexp.MustCompile(`.*/applications/notfound/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			var res struct {
@@ -178,7 +178,7 @@ func Test_topologyService_DeletePolicy(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		}
 

--- a/alien4cloud/topology_test.go
+++ b/alien4cloud/topology_test.go
@@ -1,0 +1,94 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func Test_topologyService_GetTopology(t *testing.T) {
+	ts := newHTTPServerTestTopology(t)
+	defer ts.Close()
+
+	type args struct {
+		ctx   context.Context
+		appID string
+		envID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"ExistingApp", args{context.Background(), "existingApp", "existingEnv"}, false},
+		{"UnknownApp", args{context.Background(), "unknownApp", "unknownEnv"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			topoService := &topologyService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+
+			_, err := topoService.GetTopology(tt.args.ctx, tt.args.appID, tt.args.envID)
+			if err != nil && !tt.wantErr {
+				t.Errorf("topologyService.GetTopology() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func newHTTPServerTestTopology(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/applications/unknownApp/environments/.*/topology`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			return
+		case regexp.MustCompile(`.*/applications/.*/environments/.*/topology`).Match([]byte(r.URL.Path)):
+			var res struct {
+				Data string `json:"data"`
+			}
+			res.Data = "TopologyID"
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+			return
+		case regexp.MustCompile(`.*/topologies/.*`).Match([]byte(r.URL.Path)):
+			var res Topology
+			res.Data.Topology.ArchiveName = "myArchive"
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+			return
+		}
+		// Should not go there
+		t.Errorf("Unexpected call for request %+v", r)
+	}))
+}

--- a/alien4cloud/topology_workflows_test.go
+++ b/alien4cloud/topology_workflows_test.go
@@ -78,7 +78,7 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			var res struct {
@@ -91,7 +91,7 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		}
 
@@ -165,7 +165,7 @@ func Test_topologyService_CreateAndDeleteWorkflow(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		case regexp.MustCompile(`.*/applications/.*/environments/.*/topology`).Match([]byte(r.URL.Path)):
 			var res struct {
@@ -178,7 +178,7 @@ func Test_topologyService_CreateAndDeleteWorkflow(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 			return
 		}
 		// Should not go there

--- a/alien4cloud/utils.go
+++ b/alien4cloud/utils.go
@@ -69,7 +69,7 @@ func processA4CResponse(response *http.Response, expectedData interface{}, expec
 		}
 		err = json.Unmarshal(responseBody, &res)
 		if err != nil {
-			return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud response")
+			return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud error response")
 		}
 		return errors.New(res.Error.Message)
 	}

--- a/examples/set-imput-parameters/main.go
+++ b/examples/set-imput-parameters/main.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, appName, propName, propValue string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&appName, "app", "", "Name of the application to create")
+	flag.StringVar(&propName, "property", "", "Name of the property to set")
+	flag.StringVar(&propValue, "value", "", "Value of the property to set")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	// Check required parameter
+	if appName == "" {
+		log.Panic("Mandatory argument 'app' missing (Name of the application to delete)")
+	}
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one hour (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	envID, err := client.ApplicationService().GetEnvironmentIDbyName(ctx, appName, alien4cloud.DefaultEnvironmentName)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Get input propoerties
+	topology, err := client.TopologyService().GetTopology(ctx, appName, envID)
+
+	inputProperties := topology.Data.Topology.Inputs
+
+	if _, ok := inputProperties[propName]; !ok {
+		log.Panicf("No such input property %s defined in application", propName)
+	}
+
+	updateRequest := alien4cloud.UpdateDeploymentTopologyRequest{
+		InputProperties: map[string]interface{}{
+			propName: propValue,
+		},
+	}
+
+	err = client.DeploymentService().UpdateDeploymentSetup(ctx, appName, envID, updateRequest)
+	if err != nil {
+		log.Panic(err)
+	}
+}

--- a/examples/set-input-parameters/README.md
+++ b/examples/set-input-parameters/README.md
@@ -1,0 +1,53 @@
+# Run a workflow
+
+This example shows how the Alien4Cloud go client can be used to set an application
+input property or input artifact.
+
+## Prerequisites
+
+An application has been deployed as described in [Create an deploy an application](../create-deploy-app/README.md) example.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd examples/set-input-parameters/
+go build -o setinput.test
+```
+
+Now, to set an application input property, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the name of the application
+* the input property name
+* the input property value.
+
+For example :
+
+```bash
+./setinput.test -url https://1.2.3.4:8088 \
+                -user myuser \
+                -password mypasswd \
+                -app MyApp \
+                -property myprop \
+                -value myval
+```
+
+To set an application input artifact, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the name of the application
+* the input artifact name
+* the path to input artifact file.
+
+For example :
+
+```bash
+./setinput.test -url https://1.2.3.4:8088 \
+                -user myuser \
+                -password mypasswd \
+                -app MyApp \
+                -artifact myp \
+                -file /home/user/myfile.txt
+```

--- a/examples/set-input-parameters/README.md
+++ b/examples/set-input-parameters/README.md
@@ -1,5 +1,4 @@
-# Run a workflow
-
+# Set input properties and input artifacts
 This example shows how the Alien4Cloud go client can be used to set an application
 input property or input artifact.
 

--- a/examples/set-input-parameters/README.md
+++ b/examples/set-input-parameters/README.md
@@ -34,7 +34,7 @@ For example :
                 -value myval
 ```
 
-To set an application input artifact, run this example providing in arguments:
+To set an application input artifact, run this example, providing in arguments:
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application

--- a/examples/set-input-parameters/main.go
+++ b/examples/set-input-parameters/main.go
@@ -73,13 +73,13 @@ func main() {
 		log.Panic(err)
 	}
 
-	inputProperties := topology.Data.Topology.Inputs
-
-	if _, ok := inputProperties[propName]; !ok {
-		log.Panicf("No such input property %s defined in application", propName)
-	}
-
 	if propName != "" {
+		inputProperties := topology.Data.Topology.Inputs
+
+		if _, ok := inputProperties[propName]; !ok {
+			log.Panicf("No such input property %s defined in application", propName)
+		}
+
 		updateRequest := alien4cloud.UpdateDeploymentTopologyRequest{
 			InputProperties: map[string]interface{}{
 				propName: propValue,
@@ -93,6 +93,12 @@ func main() {
 	}
 
 	if artifactName != "" {
+
+		inputArtifacts := topology.Data.Topology.InputArtifacts
+
+		if _, ok := inputArtifacts[artifactName]; !ok {
+			log.Panicf("No such input artifact %s defined in application", artifactName)
+		}
 
 		err = client.DeploymentService().UploadDeploymentInputArtifact(ctx, appName, envID, artifactName, artifactFilePath)
 		if err != nil {

--- a/examples/set-input-parameters/main.go
+++ b/examples/set-input-parameters/main.go
@@ -86,7 +86,7 @@ func main() {
 			},
 		}
 
-		err = client.DeploymentService().UpdateDeploymentSetup(ctx, appName, envID, updateRequest)
+		err = client.DeploymentService().UpdateDeploymentTopology(ctx, appName, envID, updateRequest)
 		if err != nil {
 			log.Panic(err)
 		}


### PR DESCRIPTION
Added a function `UpdateDeploymentSetup` (based on the corresponding Alien4Cloud REST API endpoint) in deployment service to set input poperties of an application.
Added a function `UploadDeploymentInputArtifact` in deployment service to set input artifacts of an application.

See readme in new example at `examples/set-input-parameters/README.md`.
