### PR TITLE
GetDeploymentStatus() returns an error for an undeployed application

### DIFF
--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -349,6 +349,11 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 		return "", err
 	}
 
+	if deploymentID == "" {
+		// Application not deployed
+		return ApplicationUndeployed, err
+	}
+
 	response, err := d.client.doWithContext(ctx,
 		"GET",
 		fmt.Sprintf("%s/deployments/%s/status", a4CRestAPIPrefix, deploymentID),
@@ -370,6 +375,7 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 }
 
 // GetCurrentDeploymentID returns current deployment ID for the given applicationID and environmentID
+// Returns an empty string if the application is undeployed
 func (d *deploymentService) GetCurrentDeploymentID(ctx context.Context, applicationID string, environmentID string) (string, error) {
 
 	response, err := d.client.doWithContext(ctx,

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -350,7 +350,7 @@ func (d *deploymentService) GetDeploymentStatus(ctx context.Context, application
 	}
 
 	if deploymentID == "" {
-		// Application not deployed
+		// Application is not deployed
 		return ApplicationUndeployed, err
 	}
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

DeploymentService().GetDeploymentStatus(ctx, appName, envID) was returning this error when called with the application name and env ID of an undeployed application:
```
Unable to get deployment status for application "appName" environment "envID": Deployment doesn't exist.
```
while it should have just returned the status UNDEPLOYED.

### What I did

GetDeploymentStatus() when calling GetDeploymentID() now checks if the returned deployment ID is empty.
If yes, it returns immediately the status UNDEPLOYED, and doesn't try like before to make another call to get more details on an inexisting deployed which will fail.

Added a unit test reproducing the issue, and passing after the fix.

## Applicable Issues

Closes #11 
 

