### PR TITLE
Feature/list topology details

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -215,6 +215,7 @@ type logsSearchRequest struct {
 type nodeTemplate struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
+	Tags string `json:"tags"`
 }
 
 // nodeType is the representation a node type
@@ -338,6 +339,7 @@ type Topology struct {
 		Topology          struct {
 			ArchiveName    string                        `json:"archiveName"`
 			ArchiveVersion string                        `json:"archiveVersion"`
+			Description    string                        `json:"description, omitempty"`
 			NodeTemplates  map[string]nodeTemplate       `json:"nodeTemplates"`
 			Inputs         map[string]PropertyDefinition `json:"inputs,omitempty"`
 			InputArtifacts map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`


### PR DESCRIPTION
Functionality added to return Topology structure for a given topologyID. 

Change Log:
 - Added tags to node template structure, this may be useful in a project we are currently working on.
 - Added description to Topology structure, again this may useful in a project we are currently working on. 
 - Changed GetTopologies to GetTopologyIDs, as this return a list of basic topology information with topologyIDs, perhaps this should be name differently (GetBasicTopologies)?.
 - Added GetTopologyByID function which takes a topologyID and returns a Topology structure, I could not find this functionality in current client. 