### PR TITLE
Feature/get deployment topology

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -337,12 +337,13 @@ type Topology struct {
 		RelationshipTypes map[string]relationshipType `json:"relationshipTypes"`
 		CapabilityTypes   map[string]capabilityType   `json:"capabilityTypes"`
 		Topology          struct {
-			ArchiveName    string                        `json:"archiveName"`
-			ArchiveVersion string                        `json:"archiveVersion"`
-			Description    string                        `json:"description, omitempty"`
-			NodeTemplates  map[string]nodeTemplate       `json:"nodeTemplates"`
-			Inputs         map[string]PropertyDefinition `json:"inputs,omitempty"`
-			InputArtifacts map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
+			ArchiveName    			string                        `json:"archiveName"`
+			ArchiveVersion 			string                        `json:"archiveVersion"`
+			Description    			string                        `json:"description, omitempty"`
+			NodeTemplates  			map[string]nodeTemplate       `json:"nodeTemplates"`
+			Inputs         			map[string]PropertyDefinition `json:"inputs,omitempty"`
+			InputArtifacts 			map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
+			UploadedInputArtifacts	map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
 		} `json:"topology"`
 	} `json:"data"`
 }


### PR DESCRIPTION
Our program requires that we can view the uploadedInputArtifacts for a given application. The method of doing this (which I could find) from the A4C API was through the Deployment Topology for the application. In the Pull request I have added a feature to return deployment topology for a given application on a given environment.

Change log:
 - Added a uploadedInputArtifacts map to Topology structure, this will omit if empty. (perhaps you would prefer if this was a new structure?)
 - Added getDeploymentTopology to application service. This will return a deployment topology in the form of s Topology structure for a given application on a given environment.

Thanks,
Aaron