### PR TITLE
Added function to cancel an execution

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -605,3 +605,9 @@ type FacetedSearchResult struct {
 	From         int `json:"from"`
 	To           int `json:"to"`
 }
+
+// cancelExecRequest is teh representation of a request to cancel an execution.
+type cancelExecRequest struct {
+	EnvironmentID string	`json:"environemntID"`
+	ExecutionID string		`json:"executionID"`
+}

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -607,7 +607,7 @@ type FacetedSearchResult struct {
 }
 
 // cancelExecRequest is teh representation of a request to cancel an execution.
-type cancelExecRequest struct {
-	EnvironmentID string	`json:"environemntID"`
-	ExecutionID string		`json:"executionID"`
+type CancelExecRequest struct {
+	EnvironmentID string	`json:"environmentId"`
+	ExecutionID string		`json:"executionId"`
 }

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -606,8 +606,8 @@ type FacetedSearchResult struct {
 	To           int `json:"to"`
 }
 
-// cancelExecRequest is teh representation of a request to cancel an execution.
+// cancelExecRequest is the representation of a request to cancel an execution.
 type CancelExecRequest struct {
-	EnvironmentID string	`json:"environmentId"`
-	ExecutionID string		`json:"executionId"`
+	EnvironmentID string `json:"environmentId"`
+	ExecutionID string   `json:"executionId"`
 }

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -74,6 +74,8 @@ type DeploymentService interface {
 	// - query allows to search a specific execution but may be empty
 	// - from and size allows to paginate results
 	GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]WorkflowExecution, FacetedSearchResult, error)
+	// Cancels execution for given environmentID and executionID
+	CancelExecution(ctx context.Context, environmentID string, executionID string) error
 }
 
 // ExecutionCallback is a function call by asynchronous operations when an execution reaches a terminal state

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -47,10 +47,8 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 func (d *deploymentService) CancelExecution(ctx context.Context, environmentID string, executionID string) error {
 
 
-	u := fmt.Sprintf("%s/executions/cancel", a4CRestAPIPrefix)
-
 	cancelExecBody, err := json.Marshal(
-		cancelExecRequest{
+		CancelExecRequest{
 			EnvironmentID: environmentID,
 			ExecutionID: executionID,
 		},
@@ -61,7 +59,7 @@ func (d *deploymentService) CancelExecution(ctx context.Context, environmentID s
 
 	_, err = d.client.doWithContext(ctx,
 		"POST",
-		u,
+		fmt.Sprintf("%s/executions/cancel", a4CRestAPIPrefix),
 		[]byte(string(cancelExecBody)),
 		[]Header{contentTypeAppJSONHeader, acceptAppJSONHeader},
 	)


### PR DESCRIPTION
Added functionality to cancel an execution using executionID and environmentID.

Change Log:
 - Added cancelExecution function to deployment_execution.go, which will
 call be /executions/cancel endpoint with given environmentID and
 executionID, this will return an error is one occurs with the request
 or nil if successful.
 - Added struct to alien4cloud_struct.go for cancelExecution request.
 - Added function prototype to deployment service, deployment.go