### PR TITLE
Incorrect Application data returned from GetApplicationByID()

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -337,13 +337,13 @@ type Topology struct {
 		RelationshipTypes map[string]relationshipType `json:"relationshipTypes"`
 		CapabilityTypes   map[string]capabilityType   `json:"capabilityTypes"`
 		Topology          struct {
-			ArchiveName    			string                        `json:"archiveName"`
-			ArchiveVersion 			string                        `json:"archiveVersion"`
-			Description    			string                        `json:"description, omitempty"`
-			NodeTemplates  			map[string]nodeTemplate       `json:"nodeTemplates"`
-			Inputs         			map[string]PropertyDefinition `json:"inputs,omitempty"`
-			InputArtifacts 			map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
-			UploadedInputArtifacts	map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
+			ArchiveName            string                        `json:"archiveName"`
+			ArchiveVersion         string                        `json:"archiveVersion"`
+			Description            string                        `json:"description,omitempty"`
+			NodeTemplates          map[string]nodeTemplate       `json:"nodeTemplates"`
+			Inputs                 map[string]PropertyDefinition `json:"inputs,omitempty"`
+			InputArtifacts         map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
+			UploadedInputArtifacts map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
 		} `json:"topology"`
 	} `json:"data"`
 }
@@ -609,5 +609,5 @@ type FacetedSearchResult struct {
 // cancelExecRequest is the representation of a request to cancel an execution.
 type CancelExecRequest struct {
 	EnvironmentID string `json:"environmentId"`
-	ExecutionID string   `json:"executionId"`
+	ExecutionID   string `json:"executionId"`
 }

--- a/examples/get-application-by-id/README.md
+++ b/examples/get-application-by-id/README.md
@@ -1,0 +1,31 @@
+# Run a workflow
+
+This example shows how the Alien4Cloud go client can be used to get an application from its ID.
+
+## Prerequisites
+
+An application has been created as described in [Create an deploy an application](../create-deploy-app/README.md) example.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd get-application-by-id
+go build -o getappbyid.test
+```
+
+Now, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the ID of the application
+
+For example, to re-use the Forge Web application sample deployed in [Create an deploy an application](../create-deploy-app/README.md) example,
+which is providing workflows **killWebServer**, **stopWebServer**, **startWebServer**, this would give :
+
+```bash
+./getappbyid.test -url https://1.2.3.4:8088 \
+           -user myuser \
+           -password mypasswd \
+           -id Myapp
+```

--- a/examples/get-application-by-id/main.go
+++ b/examples/get-application-by-id/main.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, appID string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&appID, "id", "", "ID of the application to find")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	// Check required parameters
+	if appID == "" {
+		log.Panic("Mandatory argument 'id' missing (ID of the application to find)")
+	}
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	app, err := client.ApplicationService().GetApplicationByID(ctx, appID)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Wait for the end of deployment
+	log.Printf("Found application:\n")
+	log.Printf("  ID:   %s\n", app.ID)
+	log.Printf("  Name: %s\n", app.Name)
+	log.Printf("  Tags: %v\n", app.Tags)
+
+}


### PR DESCRIPTION
Fixed an issue with GetApplicationByID() in cases where there are several application IDs with the same prefix and an underscore. The search request that was performed in the implementation returned several responses with applications having the same prefix.

A search request is not needed here, as we can just use the A4C REST API call applications/*applicationID* to get an application from its ID.

## What changed

In `alien4cloud/alien4cloud_structs.go`:
 just some formatting

In `alien4cloud/application.go`:
Updated the implementation of GetApplicationByID() to use this A4C REST API call applications/*applicationID*

In `examples`:
Added an example using this function.

Closes #17 