### PR TITLE
Failure getting details of a topology template when node templates have tags

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -215,7 +215,7 @@ type logsSearchRequest struct {
 type nodeTemplate struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
-	Tags string `json:"tags"`
+	Tags []Tag  `json:"tags,omitempty"`
 }
 
 // nodeType is the representation a node type
@@ -378,7 +378,7 @@ type Tag struct {
 type Application struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-	Tags []Tag
+	Tags []Tag  `json:"tags,omitempty"`
 }
 
 // TopologyEditor is the representation a topology template editor


### PR DESCRIPTION
Fixed a wrong type for tags that can be defined in a node template, the code was expecting a string while it should be an array of name/value pairs.

To verify, create an application template with input parameters and with node templates defining metadata (translated into node template tags by Alien4Cloud), like:

```yaml
topology_template:
  inputs:
    param1:
      type: string
      required: true
  node_templates:
    MyComponent:
      type: MyType
      metadata:
        task: preprocessing
```

Upload this template in Alien4Cloud catalog and create an application from this template.
Use the example at https://github.com/alien4cloud/alien4cloud-go-client/tree/master/examples/set-input-parameters to set the input parameter of your application:

```bash
./setinput.test -url https://1.2.3.4:8088 \
                -user myuser \
                -password mypasswd \
                -app MyApp \
                -property param1 \
                -value myval
```
It was previously failing on unmarshal error. It should now work with this fix.

Closes #19 