### PR TITLE
Add an API to retrieve events associated to a given application environment

### DIFF
--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -39,6 +39,7 @@ type Client interface {
 
 	ApplicationService() ApplicationService
 	DeploymentService() DeploymentService
+	EventService() EventService
 	LogService() LogService
 	OrchestratorService() OrchestratorService
 	TopologyService() TopologyService
@@ -113,6 +114,7 @@ type a4cClient struct {
 	client              restClient
 	applicationService  *applicationService
 	deploymentService   *deploymentService
+	eventService        *eventService
 	logService          *logService
 	orchestratorService *orchestratorService
 	topologyService     *topologyService
@@ -187,6 +189,7 @@ func NewClient(address string, user string, password string, caFile string, skip
 		password: password,
 	}
 	topoService := topologyService{restClient}
+	eventService := eventService{restClient}
 	catService := catalogService{restClient}
 	appService := applicationService{restClient, &topoService}
 	deployService := deploymentService{restClient, &appService, &topoService}
@@ -194,6 +197,7 @@ func NewClient(address string, user string, password string, caFile string, skip
 		client:              restClient,
 		applicationService:  &appService,
 		deploymentService:   &deployService,
+		eventService:        &eventService,
 		logService:          &logService{restClient, &deployService},
 		orchestratorService: &orchestratorService{restClient},
 		topologyService:     &topoService,
@@ -233,6 +237,11 @@ func (c *a4cClient) ApplicationService() ApplicationService {
 // DeploymentService retrieves the Deployment Service
 func (c *a4cClient) DeploymentService() DeploymentService {
 	return c.deploymentService
+}
+
+// Event retrieves the Event Service
+func (c *a4cClient) EventService() EventService {
+	return c.eventService
 }
 
 // LogService retrieves the Log Service

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -490,6 +490,21 @@ type RuntimeTopology struct {
 	Error Error `json:"error"`
 }
 
+// Event represents an event entry returned by the A4C REST API
+type Event struct {
+	DeploymentID         string                 `json:"deploymentId,omitempty"`
+	Date                 Time                   `json:"date,omitempty"`
+	DeploymentStatus     string                 `json:"deploymentStatus,omitempty"`
+	NodeTemplateId       string                 `json:"nodeTemplateId,omitempty"`
+	InstanceId           string                 `json:"instanceId,omitempty"`
+	InstanceState        string                 `json:"instanceState,omitempty"`
+	InstanceStatus       string                 `json:"instanceStatus,omitempty"`
+	Attributes           map[string]string      `json:"attributes,omitempty"`
+	RuntimeProperties    map[string]string      `json:"runtimeProperties,omitempty"`
+	PersistentProperties map[string]interface{} `json:"persistentProperties,omitempty"`
+	Message              string                 `json:"message,omitempty"`
+}
+
 // Log represents the log entry return by the a4c rest api
 type Log struct {
 	ID               string `json:"id"`

--- a/alien4cloud/event.go
+++ b/alien4cloud/event.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// EventService is the interface to the service mamaging events
+type EventService interface {
+	// Returns a given number of events for a given deployed application from a given index
+	// Events are sorted by date in descending order. This call returns as well
+	// the total number of events on this application
+	GetEventsForApplicationEnvironment(ctx context.Context, environmentID string, fromIndex, size int) ([]Event, int, error)
+}
+
+type eventService struct {
+	client restClient
+}
+
+// GetEventsForApplicationEnvironment returns the events for the application environment
+// Results are sorted by descending date. This call returns as well
+// the total number of events on this application
+func (e *eventService) GetEventsForApplicationEnvironment(ctx context.Context, environmentID string,
+	fromIndex, size int) ([]Event, int, error) {
+
+	var res struct {
+		Data struct {
+			Data         []Event `json:"data"`
+			From         int     `json:"from"`
+			To           int     `json:"to"`
+			TotalResults int     `json:"totalResults"`
+		} `json:"data"`
+	}
+
+	// Then we send the resquest to get the events returned for this deployment.
+	evURL := fmt.Sprintf("%s/deployments/%s/events?from=%s&size=%s", a4CRestAPIPrefix, environmentID,
+		url.QueryEscape(strconv.Itoa(fromIndex)), url.QueryEscape(strconv.Itoa(size)))
+	response, err := e.client.doWithContext(ctx,
+		"GET",
+		evURL,
+		nil,
+		[]Header{acceptAppJSONHeader},
+	)
+
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "Cannot send a request to get events from application environment '%s'", environmentID)
+	}
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "Unable to unmarshal events from response")
+	}
+
+	return res.Data.Data, res.Data.TotalResults, nil
+}

--- a/alien4cloud/event_test.go
+++ b/alien4cloud/event_test.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_eventService_GetEvents(t *testing.T) {
+	ts := newHTTPServerTestEvents(t)
+	defer ts.Close()
+
+	type args struct {
+		ctx   context.Context
+		appID string
+		envID string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantErr      bool
+		wantNbEvents int
+	}{
+		{"ExistingApp", args{context.Background(), "existingApp", "existingEnv"}, false, 1},
+		{"UnknownApp", args{context.Background(), "unknownApp", "unknownEnv"}, true, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			evService := &eventService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+
+			_, nbEvents, err := evService.GetEventsForApplicationEnvironment(tt.args.ctx, tt.args.envID, 0, 10)
+			if err != nil && !tt.wantErr {
+				t.Errorf("eventService.GetEventsOfApplication() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.wantNbEvents, nbEvents, "Unexpected number of events for app env %s", tt.args.envID)
+
+		})
+	}
+}
+
+func newHTTPServerTestEvents(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/deployments/existingEnv/events`).Match([]byte(r.URL.Path)):
+			var res struct {
+				Data struct {
+					Data         []Event `json:"data"`
+					From         int     `json:"from"`
+					To           int     `json:"to"`
+					TotalResults int     `json:"totalResults"`
+				} `json:"data"`
+			}
+			event := Event{
+				DeploymentID:     "testDeployement",
+				DeploymentStatus: "DEPLOYED",
+			}
+			res.Data.Data = []Event{event}
+			res.Data.To = 1
+			res.Data.TotalResults = 1
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+			return
+		case regexp.MustCompile(`.*/deployments/.*/events`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code": 504,"message":"Deployment does not exist"}}`))
+			return
+		}
+		// Should not go there
+		t.Errorf("Unexpected call for request %+v", r)
+	}))
+}

--- a/examples/run-workflow/README.md
+++ b/examples/run-workflow/README.md
@@ -30,8 +30,11 @@ which is providing workflows **killWebServer**, **stopWebServer**, **startWebSer
            -user myuser \
            -password mypasswd \
            -app myapp \
-           -worflow stopWebServer
+           -workflow stopWebServer
 ```
+
+You can also specify the option `-events` to see workflow events received during the workflow execution.
+Else (default case), workflow logs will be printed.
 
 ## What's next
 


### PR DESCRIPTION
Added an Event Service using the Alien4Cloud REST API `getEvents` described at http://alien4cloud.github.io/#/documentation/2.2.0/rest/controller_deployment-controller.html
to retrieve events for a given application environment.

Updated the example program at `examples/run-workflow` to display optionally events occurring during a workflow run (by default logs are displayed).

## How to test

Deploy the Welcome sample application as described at https://github.com/alien4cloud/alien4cloud-go-client/blob/master/examples/create-deploy-app

Then run the `stopWebServer` workflow as described at https://github.com/alien4cloud/alien4cloud-go-client/tree/master/examples/run-workflow using the option `-events` to see events occurring during the workflow execution on this application:

```bash
./run.test -url https://1.2.3.4:8088 \
           -user myuser \
           -password mypasswd \
           -app myapp \
           -worflow stopWebServer \
           -events
```

Check the following messages related to events appear in your terminal:

```
2020/06/08 15:32:37 Event received: component Welcome instance 0 state stopping
2020/06/08 15:32:57 Event received: component Welcome instance 0 state stopped
```

Closes #21
