### PR TITLE
Add details on node template property values

### DIFF
--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -95,6 +95,11 @@ const (
 	// NodeFailed node  a4c status
 	NodeFailed = "failed"
 	// NodeStart node  a4c status
+
+	// FunctionConcat is a function used in attribute/property values to concatenate strings
+	FunctionConcat = "concat"
+	// FunctionGetInput is a function used in attribute/property values to reference an input property
+	FunctionGetInput = "get_input"
 )
 
 const (

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -319,7 +319,7 @@ type PropertyDefinition struct {
 	Type         string        `json:"type"`
 	EntrySchema  EntrySchema   `json:"entrySchema,omitempty"`
 	Required     bool          `json:"required,omitempty"`
-	DefaultValue PropertyValue `json:"defaultValue,omitempty"`
+	DefaultValue PropertyValue `json:"default,omitempty"`
 	Description  string        `json:"description,omitempty"`
 	SuggestionID string        `json:"suggestionId,omitempty"`
 	Password     bool          `json:"password,omitempty"`

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -211,11 +211,18 @@ type logsSearchRequest struct {
 	} `json:"sortConfiguration"`
 }
 
-// nodeTemplate is the representation a node template
-type nodeTemplate struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Tags []Tag  `json:"tags,omitempty"`
+// NodeTemplatePropertyValue represents a node template property value
+type NodeTemplatePropertyValue struct {
+	Key   string        `json:"key,omitempty"`
+	Value PropertyValue `json:"value,omitempty"`
+}
+
+// NodeTemplate is the representation a node template
+type NodeTemplate struct {
+	Name       string                      `json:"name"`
+	Type       string                      `json:"type"`
+	Tags       []Tag                       `json:"tags,omitempty"`
+	Properties []NodeTemplatePropertyValue `json:"properties,omitempty"`
 }
 
 // nodeType is the representation a node type
@@ -294,8 +301,11 @@ type Deployment struct {
 
 // PropertyValue holds the definition of a property value
 type PropertyValue struct {
-	Value      interface{} `json:"value"`
-	Definition bool        `json:"definition,omitempty"`
+	Definition     bool          `json:"definition,omitempty"`
+	Value          interface{}   `json:"value,omitempty"`
+	FunctionConcat string        `json:"function_concat,omitempty"`
+	Function       string        `json:"function,omitempty"`
+	Parameters     []interface{} `json:"parameters,omitempty"`
 }
 
 // EntrySchema holds the definition of the type of an element in a list
@@ -340,7 +350,7 @@ type Topology struct {
 			ArchiveName            string                        `json:"archiveName"`
 			ArchiveVersion         string                        `json:"archiveVersion"`
 			Description            string                        `json:"description,omitempty"`
-			NodeTemplates          map[string]nodeTemplate       `json:"nodeTemplates"`
+			NodeTemplates          map[string]NodeTemplate       `json:"nodeTemplates"`
 			Inputs                 map[string]PropertyDefinition `json:"inputs,omitempty"`
 			InputArtifacts         map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
 			UploadedInputArtifacts map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`

--- a/examples/get-input-parameters/README.md
+++ b/examples/get-input-parameters/README.md
@@ -1,0 +1,32 @@
+# Get input properties
+This example shows how the Alien4Cloud go client can be used to get the input
+properties of a template and in which components these properties are used
+
+## Prerequisites
+
+An application template has been uplaoded in Alien4Cloud catalog.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd examples/get-input-parameters/
+go build -o getinputs.test
+```
+
+Now, to set an application input property, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the name of the application
+* the input property name
+* the input property value.
+
+For example :
+
+```bash
+./getinputs.test -url https://1.2.3.4:8088 \
+                -user myuser \
+                -password mypasswd \
+                -template name:ersion
+```

--- a/examples/get-input-parameters/main.go
+++ b/examples/get-input-parameters/main.go
@@ -1,0 +1,147 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, appTemplate string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&appTemplate, "template", "", "Name of the topology template to use")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	// Check required parameter
+	if appTemplate == "" {
+		log.Panic("Mandatory argument 'template' missing (Name of the topology template to use)")
+	}
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one hour (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Get input properties
+	topology, err := client.TopologyService().GetTopologyByID(ctx, appTemplate)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	inputProperties := topology.Data.Topology.Inputs
+	for propName, propDef := range inputProperties {
+		fmt.Printf("Input property %s\n", propName)
+		fmt.Printf("\ttype: %s\n", propDef.Type)
+		if propDef.Required {
+			fmt.Println("\tinput required")
+		} else {
+			fmt.Printf("\tdefault value: %+v\n", propDef.DefaultValue)
+		}
+		componentPropNames, err := getComponentPropertiesReferencingInput(topology.Data.Topology.NodeTemplates, propName)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		if len(componentPropNames) > 0 {
+			fmt.Println("\treferenced in:")
+		}
+
+		for compName, propNames := range componentPropNames {
+			fmt.Printf("\t- component %s, properties: %v\n", compName, propNames)
+
+		}
+	}
+
+}
+
+func getComponentPropertiesReferencingInput(nodeTemplates map[string]alien4cloud.NodeTemplate, propName string) (map[string][]string, error) {
+	result := make(map[string][]string)
+	var err error
+
+	for compName, nodeTemplate := range nodeTemplates {
+		var propNames []string
+		for _, prop := range nodeTemplate.Properties {
+			if prop.Value.FunctionConcat != "" {
+				// Check if the input property is referenced in one of the
+				// concat argument
+				for _, param := range prop.Value.Parameters {
+
+					var propValue alien4cloud.PropertyValue
+					mapValue, ok := param.(map[string]interface{})
+					if ok {
+						// transform it into a PropertyValue if applicable
+						jsonbody, err := json.Marshal(mapValue)
+						if err == nil {
+							err = json.Unmarshal(jsonbody, &propValue)
+						}
+						ok = (err == nil)
+					}
+					if ok && propValue.Function == alien4cloud.FunctionGetInput &&
+						isPropertyUsedInPropertyValueParameters(propName, propValue) {
+
+						propNames = append(propNames, prop.Key)
+					}
+				}
+			} else if prop.Value.Function == alien4cloud.FunctionGetInput &&
+				isPropertyUsedInPropertyValueParameters(propName, prop.Value) {
+
+				propNames = append(propNames, prop.Key)
+			}
+
+		}
+
+		if len(propNames) > 0 {
+			result[compName] = propNames
+		}
+	}
+	return result, err
+}
+
+func isPropertyUsedInPropertyValueParameters(propName string, propVal alien4cloud.PropertyValue) bool {
+	for _, param := range propVal.Parameters {
+		paramVal, ok := param.(string)
+		if ok && paramVal == propName {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
To be able to  find programmatically which node templates properties are referencing topology templates input properties, updated type `PropertyValue` to cover cases where the value is a function like `concat` or `get_input`.

Added a test printing in which components are used a toplogy template input properties.
For example, with the topology template at https://github.com/lexis-project/application-templates/blob/feature/GH-2-cloud-to-ddi/weather-climate/applications/risico/risico_template.yaml uploaded in Alien4Cloud catalog,
running the command:

```bash
./getinputs.test -url https://1.2.3.4:8088/ \
    -user muyser \
    -password mypasswd \
    -template Risico:0.1.0-SNAPSHOT
```
returns this:
```
Input property preprocessing_end_date
	type: string
	input required
	referenced in:
	- component WPS_GFS, properties: [docker_env_vars]
	- component GFSData, properties: [end_date]
Input property postprocessing_risico_run_date
	type: string
	input required
	referenced in:
	- component RISICO, properties: [docker_env_vars]
Input property preprocessing_image
	type: string
	default value: {Definition:false Value:laurentg/wps.gfs FunctionConcat: Function: Parameters:[]}
	referenced in:
	- component WPS_GFS, properties: [image]
Input property preprocessing_volumes
	type: list
	default value: {Definition:false Value:[/wps_data/gfs:/input /wps_data/output:/output /wps_data/geog/WPS_GEOG:/geogrid] FunctionConcat: Function: Parameters:[]}
	referenced in:
	- component WPS_GFS, properties: [volumes]
	- component CreatePreProcessDirs, properties: [directories]
...
```

Closes #23 
