### PR TITLE
Should be able to get deployment input property values

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -347,13 +347,14 @@ type Topology struct {
 		RelationshipTypes map[string]relationshipType `json:"relationshipTypes"`
 		CapabilityTypes   map[string]capabilityType   `json:"capabilityTypes"`
 		Topology          struct {
-			ArchiveName            string                        `json:"archiveName"`
-			ArchiveVersion         string                        `json:"archiveVersion"`
-			Description            string                        `json:"description,omitempty"`
-			NodeTemplates          map[string]NodeTemplate       `json:"nodeTemplates"`
-			Inputs                 map[string]PropertyDefinition `json:"inputs,omitempty"`
-			InputArtifacts         map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
-			UploadedInputArtifacts map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
+			ArchiveName             string                        `json:"archiveName"`
+			ArchiveVersion          string                        `json:"archiveVersion"`
+			Description             string                        `json:"description,omitempty"`
+			NodeTemplates           map[string]NodeTemplate       `json:"nodeTemplates"`
+			Inputs                  map[string]PropertyDefinition `json:"inputs,omitempty"`
+			InputArtifacts          map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
+			DeployerInputProperties map[string]PropertyValue      `json:"deployerInputProperties,omitempty"`
+			UploadedInputArtifacts  map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
 		} `json:"topology"`
 	} `json:"data"`
 }

--- a/examples/get-deployment-input-parameters/README.md
+++ b/examples/get-deployment-input-parameters/README.md
@@ -1,0 +1,30 @@
+# Get input properties values used for a given deployment
+This example shows how the Alien4Cloud go client can be used to get the 
+values of input properties used for a given deployment
+
+## Prerequisites
+
+An application has been deployed as described in [Create an deploy an application](../create-deploy-app/README.md) example.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd examples/get-deployment-input-parameters/
+go build -o get-deployment-inputs.test
+```
+
+Now, to get a deployment input property values, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the name of the application
+
+For example :
+
+```bash
+./get-deployment-inputs.test -url https://1.2.3.4:8088 \
+                             -user myuser \
+                             -password mypasswd \
+                             -app MyApp
+```

--- a/examples/get-deployment-input-parameters/main.go
+++ b/examples/get-deployment-input-parameters/main.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, appName string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&appName, "app", "", "Name of the application")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	// Check required parameter
+	if appName == "" {
+		log.Panic("Mandatory argument 'app' missing (Name of the application)")
+	}
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one hour (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	envID, err := client.ApplicationService().GetEnvironmentIDbyName(ctx, appName, alien4cloud.DefaultEnvironmentName)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	topology, err := client.ApplicationService().GetDeploymentTopology(ctx, appName, envID)
+	if err != nil {
+		log.Panic(err)
+	}
+	deployerInputProperties := topology.Data.Topology.DeployerInputProperties
+	for propName, propVal := range deployerInputProperties {
+		fmt.Printf("Input property %s, value %v\n", propName, propVal.Value)
+	}
+}


### PR DESCRIPTION
To be able to find programmatically which input property values were used for a deployment, updated type `Topology` to add an attribute `DeployerInputProperties`.

Added a test printing the values of input properties used for a deployment.
For example, with the topology template at https://github.com/lexis-project/application-templates/blob/feature/GH-2-cloud-to-ddi/weather-climate/applications/risico/risico_template.yaml uploaded in Alien4Cloud catalog and used to create and deploy an Application TestRisico,
running the command:

```bash
 ./get-deployment-inputs.test -url https://1.2.3.4:8088/ \
     -user myuser \
     -password mypasswd \
     -app TestRisico
```

returns:
```
Input property postprocessing_input_directory, value /risico_data/
Input property postprocessing_image, value laurentg/risico
Input property postprocessing_ddi_path, value project/wp7
Input property token, value mytokenvalue
Input property preprocessing_end_date, value 2020061800
Input property postprocessing_risico_run_date, value 20200617
Input property postprocessing_volumes, value [/risico_data/:/home/risico/data]
Input property preprocessing_volumes, value [/wps_data/gfs:/input /wps_data/output:/output /wps_data/geog/WPS_GEOG:/geogrid]
Input property preprocessing_image, value laurentg/wps.gfs
Input property preprocessing_start_date, value 2020061700
Input property preprocessing_output_directory, value /wps_data/output
```

Closes #25 