### PR TITLE
Feature/workflow details

### DIFF
--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -340,6 +340,36 @@ type DeploymentArtifact struct {
 	Description          string                 `json:"description,omitempty"`
 }
 
+// Activity holds a workflow activity properties
+type Activity struct {
+	Type          string `json:"type,omitempty"`
+	InterfaceName string `json:"interfaceName,omitempty"` // for activities of type org.alien4cloud.tosca.model.workflow.activities.CallOperationWorkflowActivity
+	OperationName string `json:"operationName,omitempty"` // for activities of type org.alien4cloud.tosca.model.workflow.activities.CallOperationWorkflowActivity
+	Delegate      string `json:"delegate,omitempty"`      // for activities of type org.alien4cloud.tosca.model.workflow.activities.DelegateWorkflowActivity
+	StateName     string `json:"stateName,omitempty"`     // for activities of type org.alien4cloud.tosca.model.workflow.activities.SetStateWorkflowActivity
+	Inline        string `json:"inline,omitempty"`        // for activities of type org.alien4cloud.tosca.model.workflow.activities.InlineWorkflowActivity
+}
+
+// WorkflowStep holds a workflow step properties
+type WorkflowStep struct {
+	Name           string     `json:"name,omitempty"`
+	Target         string     `json:"target,omitempty"`
+	OperationHost  string     `json:"operationHost,omitempty"`
+	Activities     []Activity `json:"activities,omitempty"`
+	OnSuccess      []string   `json:"onSuccess,omitempty"`
+	OnFailure      []string   `json:"onFailure,omitempty"`
+	PrecedingSteps []string   `json:"precedingSteps,omitempty"`
+}
+
+// Workflow holds a workflow properties
+type Workflow struct {
+	Name        string                        `json:"name,omitempty"`
+	Description string                        `json:"description,omitempty"`
+	Metadata    map[string]string             `json:"metadata,omitempty"`
+	Inputs      map[string]PropertyDefinition `json:"inputs,omitempty"`
+	Steps       map[string]WorkflowStep       `json:"steps,omitempty"`
+}
+
 // Topology is the representation a topology template
 type Topology struct {
 	Data struct {
@@ -355,6 +385,7 @@ type Topology struct {
 			InputArtifacts          map[string]DeploymentArtifact `json:"inputArtifacts,omitempty"`
 			DeployerInputProperties map[string]PropertyValue      `json:"deployerInputProperties,omitempty"`
 			UploadedInputArtifacts  map[string]DeploymentArtifact `json:"uploadedinputArtifacts,omitempty"`
+			Workflows               map[string]Workflow           `json:"workflows,omitempty"`
 		} `json:"topology"`
 	} `json:"data"`
 }
@@ -563,15 +594,31 @@ type LogFilter struct {
 	ExecutionID []string `json:"executionId,omitempty"`
 }
 
+type WorkflowStepInstance struct {
+	ID               string `json:"id,omitempty"`
+	StepId           string `json:"stepId,omitempty"`
+	DeploymentId     string `json:"deploymentId,omitempty"`
+	ExecutionId      string `json:"executionId,omitempty"`
+	NodeId           string `json:"nodeId,omitempty"`
+	InstanceId       string `json:"instanceId,omitempty"`
+	TargetNodeId     string `json:"targetNodeId,omitempty"`
+	TargetInstanceId string `json:"targetInstanceId,omitempty"`
+	OperationName    string `json:"operationName,omitempty"`
+	HasFailedTasks   bool   `json:"hasFailedTasks,omitempty"`
+	Status           string `json:"status,omitempty"`
+}
+
 // WorkflowExecution represents rest api workflow execution
 type WorkflowExecution struct {
-	ID                  string `json:"id"`
-	DeploymentID        string `json:"deploymentId"`
-	WorkflowID          string `json:"workflowId"`
-	WorkflowName        string `json:"workflowName"`
-	DisplayWorkflowName string `json:"displayWorkflowName"`
-	Status              string `json:"status"`
-	HasFailedTasks      bool   `json:"hasFailedTasks"`
+	ID                  string                          `json:"id"`
+	DeploymentID        string                          `json:"deploymentId"`
+	WorkflowID          string                          `json:"workflowId"`
+	WorkflowName        string                          `json:"workflowName"`
+	DisplayWorkflowName string                          `json:"displayWorkflowName"`
+	Status              string                          `json:"status"`
+	HasFailedTasks      bool                            `json:"hasFailedTasks"`
+	StepStatus          map[string]string               `json:"stepStatus,omitempty"`
+	StepInstances       map[string]WorkflowStepInstance `json:"stepInstances,omitempty"`
 }
 
 // Time represents the timestamp field from A4C

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -284,19 +284,19 @@ type Location struct {
 
 // Deployment is the representation a deployment
 type Deployment struct {
-	DeploymentUsername       string      `json:"deploymentUsername"`
-	EndDate                  Time        `json:"endDate"`
-	EnvironmentID            string      `json:"environmentId"`
-	ID                       string      `json:"id"`
-	LocationIds              []string    `json:"locationIds"`
-	OrchestratorDeploymentID string      `json:"orchestratorDeploymentId"`
-	OrchestratorID           string      `json:"orchestratorId"`
-	SourceID                 string      `json:"sourceId"`
-	SourceName               string      `json:"sourceName"`
-	SourceType               string      `json:"sourceType"`
-	StartDate                Time        `json:"startDate"`
-	VersionID                string      `json:"versionId"`
-	WorkflowExecutions       interface{} `json:"workflowExecutions"`
+	DeploymentUsername       string            `json:"deploymentUsername"`
+	EndDate                  Time              `json:"endDate"`
+	EnvironmentID            string            `json:"environmentId"`
+	ID                       string            `json:"id"`
+	LocationIds              []string          `json:"locationIds"`
+	OrchestratorDeploymentID string            `json:"orchestratorDeploymentId"`
+	OrchestratorID           string            `json:"orchestratorId"`
+	SourceID                 string            `json:"sourceId"`
+	SourceName               string            `json:"sourceName"`
+	SourceType               string            `json:"sourceType"`
+	StartDate                Time              `json:"startDate"`
+	VersionID                string            `json:"versionId"`
+	WorkflowExecutions       map[string]string `json:"workflowExecutions"`
 }
 
 // PropertyValue holds the definition of a property value
@@ -610,15 +610,20 @@ type WorkflowStepInstance struct {
 
 // WorkflowExecution represents rest api workflow execution
 type WorkflowExecution struct {
-	ID                  string                          `json:"id"`
-	DeploymentID        string                          `json:"deploymentId"`
-	WorkflowID          string                          `json:"workflowId"`
-	WorkflowName        string                          `json:"workflowName"`
-	DisplayWorkflowName string                          `json:"displayWorkflowName"`
-	Status              string                          `json:"status"`
-	HasFailedTasks      bool                            `json:"hasFailedTasks"`
-	StepStatus          map[string]string               `json:"stepStatus,omitempty"`
-	StepInstances       map[string]WorkflowStepInstance `json:"stepInstances,omitempty"`
+	Execution     Execution                         `json:"execution,omitempty"`
+	StepStatus    map[string]string                 `json:"stepStatus,omitempty"`
+	StepInstances map[string][]WorkflowStepInstance `json:"stepInstances,omitempty"`
+}
+
+// Execution hold properties of the execution of a workflow
+type Execution struct {
+	ID                  string `json:"id"`
+	DeploymentID        string `json:"deploymentId"`
+	WorkflowID          string `json:"workflowId"`
+	WorkflowName        string `json:"workflowName"`
+	DisplayWorkflowName string `json:"displayWorkflowName"`
+	Status              string `json:"status"`
+	HasFailedTasks      bool   `json:"hasFailedTasks"`
 }
 
 // Time represents the timestamp field from A4C

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -594,6 +594,7 @@ type LogFilter struct {
 	ExecutionID []string `json:"executionId,omitempty"`
 }
 
+// WorkflowStepInstance holds properties of a workflow step instance
 type WorkflowStepInstance struct {
 	ID               string `json:"id,omitempty"`
 	StepId           string `json:"stepId,omitempty"`

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -2,16 +2,16 @@ package alien4cloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
-	"encoding/json"
 
 	"github.com/pkg/errors"
 )
 
-func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]WorkflowExecution, FacetedSearchResult, error) {
+func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]Execution, FacetedSearchResult, error) {
 	u := fmt.Sprintf("%s/executions/search?from=%s&size=%s", a4CRestAPIPrefix, url.QueryEscape(strconv.Itoa(from)), url.QueryEscape(strconv.Itoa(size)))
 
 	if deploymentID != "" {
@@ -34,8 +34,8 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 
 	var res struct {
 		Data struct {
-			Types []string            `json:"types"`
-			Data  []WorkflowExecution `json:"data"`
+			Types []string    `json:"types"`
+			Data  []Execution `json:"data"`
 			FacetedSearchResult
 		} `json:"data"`
 	}
@@ -46,11 +46,10 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 
 func (d *deploymentService) CancelExecution(ctx context.Context, environmentID string, executionID string) error {
 
-
 	cancelExecBody, err := json.Marshal(
 		CancelExecRequest{
 			EnvironmentID: environmentID,
-			ExecutionID: executionID,
+			ExecutionID:   executionID,
 		},
 	)
 	if err != nil {
@@ -63,7 +62,7 @@ func (d *deploymentService) CancelExecution(ctx context.Context, environmentID s
 		[]byte(string(cancelExecBody)),
 		[]Header{contentTypeAppJSONHeader, acceptAppJSONHeader},
 	)
-	
+
 	if err != nil {
 		return errors.Wrapf(err, "Failed to cancel execution for execution '%s' on environment '%s'", executionID, environmentID)
 	}

--- a/alien4cloud/deployment_execution_test.go
+++ b/alien4cloud/deployment_execution_test.go
@@ -53,29 +53,29 @@ func Test_deploymentService_GetExecutions(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []WorkflowExecution
+		want    []Execution
 		want1   FacetedSearchResult
 		wantErr bool
 	}{
 		{"normal", args{context.Background(), "normal", "", 1, 1},
-			[]WorkflowExecution{
-				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+			[]Execution{
+				Execution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
 			},
 			FacetedSearchResult{TotalResults: 3, From: 1, To: 1},
 			false,
 		},
 		{"query", args{context.Background(), "query", "7459ca00-f98f-47f1-a7e8-4d779d65253a", 0, 1},
-			[]WorkflowExecution{
-				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+			[]Execution{
+				Execution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
 			},
 			FacetedSearchResult{TotalResults: 1, From: 0, To: 0},
 			false,
 		},
 		{"multi", args{context.Background(), "multi", "", 0, 10},
-			[]WorkflowExecution{
-				WorkflowExecution{ID: "d9f63781-5245-4cd0-a24c-b83d4c4842f1", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "startWebServer", WorkflowName: "startWebServer", DisplayWorkflowName: "startWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
-				WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
-				WorkflowExecution{ID: "e8cbb5bd-5f85-408e-9190-caee179d0581", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "install", WorkflowName: "install", DisplayWorkflowName: "install", Status: "SUCCEEDED", HasFailedTasks: false},
+			[]Execution{
+				Execution{ID: "d9f63781-5245-4cd0-a24c-b83d4c4842f1", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "startWebServer", WorkflowName: "startWebServer", DisplayWorkflowName: "startWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+				Execution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+				Execution{ID: "e8cbb5bd-5f85-408e-9190-caee179d0581", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "install", WorkflowName: "install", DisplayWorkflowName: "install", Status: "SUCCEEDED", HasFailedTasks: false},
 			},
 			FacetedSearchResult{TotalResults: 3, From: 0, To: 2},
 			false,

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -294,11 +294,11 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *WorkflowExecution
+		want    *Execution
 		wantErr bool
 	}{
 		{"Normal", args{context.Background(), "app", "env", "wf", 5 * time.Minute},
-			&WorkflowExecution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
+			&Execution{ID: "7459ca00-f98f-47f1-a7e8-4d779d65253a", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "stopWebServer", WorkflowName: "stopWebServer", DisplayWorkflowName: "stopWebServer", Status: "SUCCEEDED", HasFailedTasks: false},
 			false,
 		},
 		{"EmptyExecID", args{context.Background(), "emptyExecID", "env", "wf", 5 * time.Minute}, nil, true},

--- a/alien4cloud/topology_workflows.go
+++ b/alien4cloud/topology_workflows.go
@@ -15,6 +15,13 @@ const (
 	SetStateWorkflowActivityType = "org.alien4cloud.tosca.model.workflow.activities.SetStateWorkflowActivity"
 	// DelegateWorkflowActivity is the type of an activity delegated to an orchestrator
 	DelegateWorkflowActivity = "org.alien4cloud.tosca.model.workflow.activities.DelegateWorkflowActivity"
+
+	// StepStarted is the status of a workflow step that is started (currently running, not yet completed)
+	StepStarted = "STARTED"
+	// StepCompletedSuccessfull is the status of a workflow step that has completed successfully
+	StepCompletedSuccessfull = "COMPLETED_SUCCESSFULL"
+	// StepCompletedSuccessfull is the status of a workflow step that has failed
+	StepCompletedWithError = "COMPLETED_WITH_ERROR"
 )
 
 // WorkflowActivity is a workflow activity payload.

--- a/alien4cloud/topology_workflows.go
+++ b/alien4cloud/topology_workflows.go
@@ -7,9 +7,14 @@ import (
 )
 
 const (
-	callOperationWorkflowActivityType = "org.alien4cloud.tosca.model.workflow.activities.CallOperationWorkflowActivity"
-	inlineWorkflowActivityType        = "org.alien4cloud.tosca.model.workflow.activities.InlineWorkflowActivity"
-	setStateWorkflowActivityType      = "org.alien4cloud.tosca.model.workflow.activities.SetStateWorkflowActivity"
+	// CallOperationWorkflowActivityType is the type of a call operation activity
+	CallOperationWorkflowActivityType = "org.alien4cloud.tosca.model.workflow.activities.CallOperationWorkflowActivity"
+	// InlineWorkflowActivityType is the type of an inline workflow activity
+	InlineWorkflowActivityType = "org.alien4cloud.tosca.model.workflow.activities.InlineWorkflowActivity"
+	// SetStateWorkflowActivityType is the type of an activity setting the state of a component
+	SetStateWorkflowActivityType = "org.alien4cloud.tosca.model.workflow.activities.SetStateWorkflowActivity"
+	// DelegateWorkflowActivity is the type of an activity delegated to an orchestrator
+	DelegateWorkflowActivity = "org.alien4cloud.tosca.model.workflow.activities.DelegateWorkflowActivity"
 )
 
 // WorkflowActivity is a workflow activity payload.
@@ -50,7 +55,7 @@ func (wa *WorkflowActivity) AppendAfter(stepName string) *WorkflowActivity {
 // OperationCall allows to configure the workflow activity to be an operation call activity
 // targetRelationship is optional and applies only on relationships-related operations
 func (wa *WorkflowActivity) OperationCall(target, targetRelationship, interfaceName, operationName string) *WorkflowActivity {
-	wa.activitytype = callOperationWorkflowActivityType
+	wa.activitytype = CallOperationWorkflowActivityType
 	wa.target = target
 	wa.targetRelationship = targetRelationship
 	wa.interfaceName = interfaceName
@@ -60,14 +65,14 @@ func (wa *WorkflowActivity) OperationCall(target, targetRelationship, interfaceN
 
 // InlineWorkflow allows to configure the workflow activity to be an inline workflow activity
 func (wa *WorkflowActivity) InlineWorkflow(inlineWorkflow string) *WorkflowActivity {
-	wa.activitytype = inlineWorkflowActivityType
+	wa.activitytype = InlineWorkflowActivityType
 	wa.inline = inlineWorkflow
 	return wa
 }
 
 // SetState allows to configure the workflow activity to be an inline workflow call
 func (wa *WorkflowActivity) SetState(target, stateName string) *WorkflowActivity {
-	wa.activitytype = setStateWorkflowActivityType
+	wa.activitytype = SetStateWorkflowActivityType
 	wa.target = target
 	wa.stateName = stateName
 	return wa
@@ -133,13 +138,15 @@ func (t *topologyService) AddWorkflowActivity(ctx context.Context, a4cCtx *Topol
 	}
 
 	switch activity.activitytype {
-	case setStateWorkflowActivityType:
+	case SetStateWorkflowActivityType:
 		req.Activity.StateName = activity.stateName
-	case inlineWorkflowActivityType:
+	case InlineWorkflowActivityType:
 		req.Activity.Inline = activity.inline
-	case callOperationWorkflowActivityType:
+	case CallOperationWorkflowActivityType:
 		req.Activity.InterfaceName = activity.interfaceName
 		req.Activity.OperationName = activity.operationName
+	default:
+		return errors.Errorf("Unenexpected activity type %s", activity.activitytype)
 	}
 	err := t.editTopology(ctx, a4cCtx, req)
 	return errors.Wrapf(err, "Unable to add activity to workflow %q in topology of application %q and environment %q", workflowName, a4cCtx.AppID, a4cCtx.EnvID)

--- a/alien4cloud/topology_workflows_test.go
+++ b/alien4cloud/topology_workflows_test.go
@@ -29,18 +29,18 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 			}
 
 			switch awaReq.Activity.Type {
-			case inlineWorkflowActivityType:
+			case InlineWorkflowActivityType:
 				if awaReq.Activity.Inline == "" {
 					t.Error("Missing inline workflow name")
 				}
-			case setStateWorkflowActivityType:
+			case SetStateWorkflowActivityType:
 				if awaReq.Activity.StateName == "" {
 					t.Error("Missing inline State name")
 				}
 				if awaReq.Target == "" {
 					t.Error("Missing target name")
 				}
-			case callOperationWorkflowActivityType:
+			case CallOperationWorkflowActivityType:
 				if awaReq.Activity.InterfaceName == "" {
 					t.Error("Missing inline interface name")
 				}

--- a/alien4cloud/topology_workflows_test.go
+++ b/alien4cloud/topology_workflows_test.go
@@ -99,6 +99,9 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 		t.Errorf("Unexpected call for request %+v", r)
 	}))
 
+	wrongActivity := WorkflowActivity{
+		activitytype: "WrongActivity",
+	}
 	type args struct {
 		ctx          context.Context
 		a4cCtx       *TopologyEditorContext
@@ -119,6 +122,9 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 		{"AddCallOp", args{context.Background(),
 			&TopologyEditorContext{AppID: "test", EnvID: "test", TopologyID: "tid"}, "wf",
 			newWfActivity().OperationCall("mynode", "rel", "ifce", "opName").InsertBefore("myotherStep")}, false},
+		{"AddWrongActivity", args{context.Background(),
+			&TopologyEditorContext{AppID: "test", EnvID: "test", TopologyID: "tid"}, "wf",
+			wrongActivity.InsertBefore("myotherStep")}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/examples/get-workflow-status/README.md
+++ b/examples/get-workflow-status/README.md
@@ -1,0 +1,34 @@
+# Run a workflow
+
+This example shows how the Alien4Cloud go client can be used to get the status of
+a workflow execution.
+
+## Prerequisites
+
+An application has been deployed as described in [Create an deploy an application](../create-deploy-app/README.md) example.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd examples/get-workflow-status
+go build -o wfstatus.test
+```
+
+Now, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of the user who has deployed the application
+* the name of the application
+* the name of the workflow for which to get the status.
+
+For example, to re-use the Forge Web application sample deployed in [Create an deploy an application](../create-deploy-app/README.md) example,
+which is providing workflows **Install**, **killWebServer**, **stopWebServer**, **startWebServer**, this would give :
+
+```bash
+./wfstatus.test -url https://1.2.3.4:8088 \
+           -user myuser \
+           -password mypasswd \
+           -app myapp \
+           -workflow install
+```

--- a/examples/get-workflow-status/main.go
+++ b/examples/get-workflow-status/main.go
@@ -156,11 +156,11 @@ func getStepStatus(step *alien4cloud.WorkflowStep, wfExec *alien4cloud.WorkflowE
 func printStep(description, status string) {
 
 	switch status {
-	case "COMPLETED_SUCCESSFULL":
+	case alien4cloud.StepCompletedSuccessfull:
 		color.New(color.FgGreen).Printf("%s", description)
-	case "COMPLETED_WITH_ERROR":
+	case alien4cloud.StepCompletedWithError:
 		color.New(color.FgRed).Printf("%s", description)
-	case "STARTED":
+	case alien4cloud.StepStarted:
 		color.New(color.FgBlue).Printf("%s", description)
 	default:
 		fmt.Printf("%s", description)

--- a/examples/get-workflow-status/main.go
+++ b/examples/get-workflow-status/main.go
@@ -1,0 +1,224 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+)
+
+// Command arguments
+var url, user, password, appName, workflow string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&appName, "app", "", "Name of the application to create")
+	flag.StringVar(&workflow, "workflow", "", "Name of the workflow to run")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	// Check required parameters
+	if appName == "" {
+		log.Panic("Mandatory argument 'app' missing (Name of the application to create)")
+	}
+	if workflow == "" {
+		log.Panic("Mandatory argument 'workflow' missing (Name of the workflow to run)")
+	}
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one hour (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	envID, err := client.ApplicationService().GetEnvironmentIDbyName(ctx, appName, alien4cloud.DefaultEnvironmentName)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Get workflow description
+	topo, err := client.ApplicationService().GetDeploymentTopology(ctx, appName, envID)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	wf, found := topo.Data.Topology.Workflows[workflow]
+	if !found {
+		log.Panicf("Found no workflow %s in application %s", appName, workflow)
+	}
+	// Identify initial steps
+	var initialSteps []alien4cloud.WorkflowStep
+	for _, wfStep := range wf.Steps {
+		if len(wfStep.PrecedingSteps) == 0 {
+			initialSteps = append(initialSteps, wfStep)
+		}
+	}
+
+	// Get workflow steps status
+	wfExec, err := client.DeploymentService().GetLastWorkflowExecution(ctx, appName, envID)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Print workflow steps status
+	for _, step := range initialSteps {
+		description, err := getStepDescription(&step)
+		if err != nil {
+			log.Panic(err)
+		}
+		status, err := getStepStatus(&step, wfExec)
+		if err != nil {
+			log.Panic(err)
+		}
+		printStep(description, status)
+		if len(step.OnSuccess) > 0 {
+			err := printNextSteps(step.OnSuccess, wf, wfExec, len(description))
+			if err != nil {
+				log.Panic(err)
+			}
+		} else {
+			fmt.Println("")
+		}
+
+	}
+}
+
+func getStep(stepName string, wf alien4cloud.Workflow) (*alien4cloud.WorkflowStep, error) {
+	for _, wfStep := range wf.Steps {
+		if wfStep.Name == stepName {
+			return &wfStep, nil
+		}
+	}
+
+	return nil, errors.Errorf("No such step %s in workflow %s", stepName, wf.Name)
+}
+
+func getStepDescription(step *alien4cloud.WorkflowStep) (string, error) {
+	var description string
+	var err error
+	if len(step.Activities) != 1 {
+		return description, errors.Errorf("This example expects 1 workflow step activity, got %d for step %s",
+			len(step.Activities), step.Name)
+	}
+	activity := step.Activities[0]
+	switch activity.Type {
+	case alien4cloud.CallOperationWorkflowActivityType:
+		description = fmt.Sprintf("%s %s", step.Target, activity.OperationName)
+	case alien4cloud.DelegateWorkflowActivity:
+		description = fmt.Sprintf("%s %s", step.Target, activity.Delegate)
+	case alien4cloud.SetStateWorkflowActivityType:
+		description = fmt.Sprintf("%s %s", step.Target, activity.StateName)
+	case alien4cloud.InlineWorkflowActivityType:
+		description = fmt.Sprintf("Workflow %s", activity.Inline)
+	default:
+		err = errors.Errorf("Unexpected activity type %s for step %s", activity.Type, step.Name)
+	}
+	return description, err
+}
+
+func getStepStatus(step *alien4cloud.WorkflowStep, wfExec *alien4cloud.WorkflowExecution) (string, error) {
+	var err error
+	status, found := wfExec.StepStatus[step.Name]
+	if !found {
+		// steps setting a state are not described in the workflow execution
+		if step.Activities[0].Type == alien4cloud.SetStateWorkflowActivityType {
+			status = "unknown"
+		} else {
+			err = errors.Errorf("Found no status for step %s in workflow %s", step.Name, wfExec.Execution.WorkflowName)
+		}
+	}
+
+	return status, err
+}
+
+func printStep(description, status string) {
+
+	switch status {
+	case "COMPLETED_SUCCESSFULL":
+		color.New(color.FgGreen).Printf("%s", description)
+	case "COMPLETED_WITH_ERROR":
+		color.New(color.FgRed).Printf("%s", description)
+	case "STARTED":
+		color.New(color.FgBlue).Printf("%s", description)
+	default:
+		fmt.Printf("%s", description)
+	}
+}
+
+func printNextSteps(stepNames []string, wf alien4cloud.Workflow, wfExec *alien4cloud.WorkflowExecution, indent int) error {
+
+	for i, stepName := range stepNames {
+		if i != 0 {
+			fmt.Printf("%s", strings.Repeat(" ", indent))
+		}
+		step, err := getStep(stepName, wf)
+		if err != nil {
+			return err
+		}
+
+		description, err := getStepDescription(step)
+		if err != nil {
+			return err
+		}
+		status, err := getStepStatus(step, wfExec)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		var newIdentation int
+		if status == "unknown" {
+			// Skipping steps with an unknown status corresponding to steps setting a state
+			// The status of such steps is not available in the workflow execution
+			newIdentation = 0
+		} else {
+			fmt.Printf(" -> ")
+			printStep(description, status)
+			newIdentation = len(description) + 4
+		}
+
+		if len(step.OnSuccess) > 0 {
+			err := printNextSteps(step.OnSuccess, wf, wfExec, indent+newIdentation)
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Println("")
+		}
+	}
+	return nil
+}

--- a/examples/run-workflow/main.go
+++ b/examples/run-workflow/main.go
@@ -69,7 +69,7 @@ func main() {
 		log.Panic(err)
 	}
 	closeCh := make(chan struct{})
-	var cb alien4cloud.ExecutionCallback = func(wfExec *alien4cloud.WorkflowExecution, cbe error) {
+	var cb alien4cloud.ExecutionCallback = func(wfExec *alien4cloud.Execution, cbe error) {
 		if wfExec != nil {
 			log.Printf("Workflow ended with status: %s\n", wfExec.Status)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alien4cloud/alien4cloud-go-client/v2
 go 1.13
 
 require (
+	github.com/fatih/color v1.9.0
 	github.com/goware/urlx v0.3.1
 	github.com/pkg/errors v0.8.2-0.20200103112531-6d954f502eb8
 	gotest.tools/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,17 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/goware/urlx v0.3.1 h1:BbvKl8oiXtJAzOzMqAQ0GfIhf96fKeNEZfm9ocNSUBI=
 github.com/goware/urlx v0.3.1/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.2-0.20200103112531-6d954f502eb8 h1:6Q0Pba5ApucEalgE23RPDWONYEZEbG9xC2vxuj+k8h0=
@@ -18,6 +25,9 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added fields/structs allowing to get details of a workflow execution: sequences of steps and steps statuses
 
### What I did

`alien4cloud/alien4cloud_structs.go`
Updated structure `Topology` to add a field `Workflows` and structs `Workflow`, `WorkflowStep`, `Activity` providing a static description of workflows: which steps compose a workflow and how these steps are sequenced (which steps will be executed after a given step has completed successfully or has failed).
To get this static description, call `ApplicationService.GetDeploymentTopology()`.

To be consistent with Alien4Cloud REST API, renamed type `WorkflowExecution` as `Execution`, and added a new type `WorkflowExecution` containing an `Execution` field as well as a field `StepStatus` providing the details of steps statuses.
This is provided by the call to `DeploymentService.GetLastWorkflowExecution()`.

`alien4cloud/topology_workflows.go`:
Made constants for activity types public.
Added constants for steps statuses.

`examples/get-workflow-status/README.md` and `examples/get-workflow-status/main.go`
Example displaying steps statuses of a workflow.


Other files:
Changes related to the renaming of type `WorkflowExection` to `Execution` and constants.


### How to verify it

Build the example:

```bash
cd examples/get-workflow-status
go build -o wfstatus.test
```

Run the example to see the workflow execution status of a deployed application.
For example, to get the workflow status of a deployed application `Myapp`, workflow `Run`:

```bash
./wfstatus.test -url https://1.2.3.4:8088 \
           -user myuser \
           -password mypasswd \
           -app Myapp \
           -workflow Run
``` 

This an example of output result where,
* steps appearing in green are steps that completed successfully,
* the step is blue is a step currently running (started)
* steps in default color (black here) are steps not yet started:

(click to zoom)

![workflow](https://user-images.githubusercontent.com/33217305/92713863-c3c0fe00-f35b-11ea-95d2-502d1f97a70c.png)


## Applicable Issues

* Closes #27 
