### PR TITLE
Added a User Service to provide CRUD operations on users/groups

### DIFF
--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -44,6 +44,7 @@ type Client interface {
 	OrchestratorService() OrchestratorService
 	TopologyService() TopologyService
 	CatalogService() CatalogService
+	// UserService() UserService
 }
 
 const (

--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -44,7 +44,7 @@ type Client interface {
 	OrchestratorService() OrchestratorService
 	TopologyService() TopologyService
 	CatalogService() CatalogService
-	// UserService() UserService
+	UserService() UserService
 }
 
 const (
@@ -101,6 +101,15 @@ const (
 	FunctionConcat = "concat"
 	// FunctionGetInput is a function used in attribute/property values to reference an input property
 	FunctionGetInput = "get_input"
+
+	// ROLE_ADMIN is the adminstrator role
+	ROLE_ADMIN = "ADMIN"
+	// ROLE_COMPONENTS_MANAGER allows to define packages on how to install, configure, start and connect components (mapped as node types)
+	ROLE_COMPONENTS_MANAGER = "COMPONENTS_MANAGER"
+	// ROLE_ARCHITECT allows to define application templates (topologies) by reusing building blocks (node types defined by components managers)
+	ROLE_ARCHITECT = "ARCHITECT"
+	// ROLE_APPLICATIONS_MANAGER allows to define applications with it’s own topologies that can be linked to a global topology from architects and that can reuse components defined by the components managers
+	ROLE_APPLICATIONS_MANAGER = "APPLICATIONS_MANAGER"
 )
 
 const (
@@ -125,6 +134,7 @@ type a4cClient struct {
 	orchestratorService *orchestratorService
 	topologyService     *topologyService
 	catalogService      *catalogService
+	userService         *userService
 }
 
 // NewClient instanciates and returns Client
@@ -199,6 +209,7 @@ func NewClient(address string, user string, password string, caFile string, skip
 	catService := catalogService{restClient}
 	appService := applicationService{restClient, &topoService}
 	deployService := deploymentService{restClient, &appService, &topoService}
+	userService := userService{restClient}
 	return &a4cClient{
 		client:              restClient,
 		applicationService:  &appService,
@@ -208,6 +219,7 @@ func NewClient(address string, user string, password string, caFile string, skip
 		orchestratorService: &orchestratorService{restClient},
 		topologyService:     &topoService,
 		catalogService:      &catService,
+		userService:         &userService,
 	}, nil
 }
 
@@ -268,6 +280,11 @@ func (c *a4cClient) TopologyService() TopologyService {
 // CatalogService retrieves the Catalog Service
 func (c *a4cClient) CatalogService() CatalogService {
 	return c.catalogService
+}
+
+// UserService retrieves the User Service
+func (c *a4cClient) UserService() UserService {
+	return c.userService
 }
 
 // do requests the alien4cloud rest api with a Context that can be canceled

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -189,11 +189,11 @@ type SimpleMark struct {
 	Column int `json:"column,omitempty"`
 }
 
-// searchRequest is the representation of a request to search objects as tpologies, orchestrators in the A4C catalog
-type searchRequest struct {
+// SearchRequest is the representation of a request to search objects such as topologies, orchestrators in the A4C catalog
+type SearchRequest struct {
 	Query string `json:"query,omitempty"`
-	From  string `json:"from"`
-	Size  string `json:"size"`
+	From  int    `json:"from,omitempty"`
+	Size  int    `json:"size,omitempty"`
 }
 
 // logsSearchRequest is the representation of a request to search logs of an application in the A4C catalog
@@ -712,8 +712,8 @@ type UpdateUserRequest struct {
 
 // User hosts an Alien4Cloud user properties
 type User struct {
-	Username  string   `json:"username"`
-	Password  string   `json:"password,omitempty"`
+	Username string `json:"username"`
+	//Password  string   `json:"password,omitempty"`
 	FirstName string   `json:"firstName,omitempty"`
 	LastName  string   `json:"lastName,omitempty"`
 	Email     string   `json:"email,omitempty"`

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -691,28 +691,9 @@ type CancelExecRequest struct {
 	ExecutionID   string `json:"executionId"`
 }
 
-// CreateUserRequest holds parameters of a requets to create a user
-type CreateUserRequest struct {
-	Username  string   `json:"username"`
-	Password  string   `json:"password,omitempty"`
-	FirstName string   `json:"firstName,omitempty"`
-	LastName  string   `json:"lastName,omitempty"`
-	Email     string   `json:"email,omitempty"`
-	Roles     []string `json:"roles,omitempty"`
-}
-
-// UpdateUserRequest holds parameters of a requets to update a sser
-type UpdateUserRequest struct {
-	Password  string   `json:"password,omitempty"`
-	FirstName string   `json:"firstName,omitempty"`
-	LastName  string   `json:"lastName,omitempty"`
-	Email     string   `json:"email,omitempty"`
-	Roles     []string `json:"roles,omitempty"`
-}
-
 // User hosts an Alien4Cloud user properties
 type User struct {
-	Username string `json:"username"`
+	UserName string `json:"username"`
 	//Password  string   `json:"password,omitempty"`
 	FirstName string   `json:"firstName,omitempty"`
 	LastName  string   `json:"lastName,omitempty"`
@@ -720,22 +701,14 @@ type User struct {
 	Roles     []string `json:"roles,omitempty"`
 }
 
-// CreateGroupRequest holds parameters of a requets to create a group
-type CreateGroupRequest struct {
-	Name        string   `json:"name"`
-	Email       string   `json:"email,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Users       []string `json:"users,omitempty"`
-	Roles       []string `json:"roles,omitempty"`
-}
-
-// UpdateUserRequest holds parameters of a requets to update a group
-type UpdateGroupRequest struct {
-	Name        string   `json:"name"`
-	Email       string   `json:"email,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Users       []string `json:"users,omitempty"`
-	Roles       []string `json:"roles,omitempty"`
+// CreateUserRequest holds parameters of a requets to create or update a user
+type CreateUpdateUserRequest struct {
+	UserName  string   `json:"username"`
+	FirstName string   `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName,omitempty"`
+	Email     string   `json:"email,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+	Password  string   `json:"password,omitempty"`
 }
 
 // Group hosts an Alien4Cloud user properties

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -690,3 +690,59 @@ type CancelExecRequest struct {
 	EnvironmentID string `json:"environmentId"`
 	ExecutionID   string `json:"executionId"`
 }
+
+// CreateUserRequest holds parameters of a requets to create a user
+type CreateUserRequest struct {
+	Username  string   `json:"username"`
+	Password  string   `json:"password,omitempty"`
+	FirstName string   `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName,omitempty"`
+	Email     string   `json:"email,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+}
+
+// UpdateUserRequest holds parameters of a requets to update a sser
+type UpdateUserRequest struct {
+	Password  string   `json:"password,omitempty"`
+	FirstName string   `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName,omitempty"`
+	Email     string   `json:"email,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+}
+
+// User hosts an Alien4Cloud user properties
+type User struct {
+	Username  string   `json:"username"`
+	Password  string   `json:"password,omitempty"`
+	FirstName string   `json:"firstName,omitempty"`
+	LastName  string   `json:"lastName,omitempty"`
+	Email     string   `json:"email,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+}
+
+// CreateGroupRequest holds parameters of a requets to create a group
+type CreateGroupRequest struct {
+	Name        string   `json:"name"`
+	Email       string   `json:"email,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Users       []string `json:"users,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+}
+
+// UpdateUserRequest holds parameters of a requets to update a group
+type UpdateGroupRequest struct {
+	Name        string   `json:"name"`
+	Email       string   `json:"email,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Users       []string `json:"users,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+}
+
+// Group hosts an Alien4Cloud user properties
+type Group struct {
+	Name        string   `json:"name"`
+	Email       string   `json:"email,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Users       []string `json:"users,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+}

--- a/alien4cloud/application.go
+++ b/alien4cloud/application.go
@@ -93,13 +93,13 @@ func (a *applicationService) CreateAppli(ctx context.Context, appName string, ap
 func (a *applicationService) GetEnvironmentIDbyName(ctx context.Context, appID string, envName string) (string, error) {
 
 	envsSearchBody, err := json.Marshal(
-		searchRequest{
-			From: "0",
-			Size: "20",
+		SearchRequest{
+			From: 0,
+			Size: 0,
 		},
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "Cannot marshal a searchRequest structure")
+		return "", errors.Wrap(err, "Cannot marshal a SearchRequest structure")
 	}
 
 	response, err := a.client.doWithContext(ctx,
@@ -171,15 +171,15 @@ func (a *applicationService) IsApplicationExist(ctx context.Context, application
 func (a *applicationService) GetApplicationsID(ctx context.Context, filter string) ([]string, error) {
 
 	appsSearchBody, err := json.Marshal(
-		searchRequest{
+		SearchRequest{
 			filter,
-			"0",
-			"",
+			0,
+			0,
 		},
 	)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot marshal an searchRequest structure")
+		return nil, errors.Wrap(err, "Cannot marshal a SearchRequest structure")
 	}
 
 	response, err := a.client.doWithContext(ctx,

--- a/alien4cloud/application_test.go
+++ b/alien4cloud/application_test.go
@@ -159,7 +159,7 @@ func newHTTPServerTestApplicationSearch(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if regexp.MustCompile(`.*/applications`).Match([]byte(r.URL.Path)) {
 
-			var searchReq searchRequest
+			var searchReq SearchRequest
 			rb, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Failed to read request body %+v", r)

--- a/alien4cloud/orchestrator.go
+++ b/alien4cloud/orchestrator.go
@@ -78,10 +78,10 @@ func (o *orchestratorService) GetOrchestratorLocations(ctx context.Context, orch
 // GetOrchestratorIDbyName Return the Alien4Cloud orchestrator ID from a given orchestator name
 func (o *orchestratorService) GetOrchestratorIDbyName(ctx context.Context, orchestratorName string) (string, error) {
 
-	orchestratorsSearchBody, err := json.Marshal(searchRequest{orchestratorName, "0", "1"})
+	orchestratorsSearchBody, err := json.Marshal(SearchRequest{orchestratorName, 0, 1})
 
 	if err != nil {
-		return "", errors.Wrap(err, "Cannot marshal an searchRequest structure")
+		return "", errors.Wrap(err, "Cannot marshal a SearchRequest structure")
 	}
 
 	response, err := o.client.doWithContext(ctx,

--- a/alien4cloud/topology.go
+++ b/alien4cloud/topology.go
@@ -96,9 +96,9 @@ func (t *topologyService) GetTopologyID(ctx context.Context, appID string, envID
 // GetTopologyTemplateIDByName return the topology template ID for the given topologyName
 func (t *topologyService) GetTopologyTemplateIDByName(ctx context.Context, topologyName string) (string, error) {
 
-	toposSearchBody, err := json.Marshal(searchRequest{topologyName, "0", "1"})
+	toposSearchBody, err := json.Marshal(SearchRequest{topologyName, 0, 1})
 	if err != nil {
-		return "", errors.Wrap(err, "Cannot marshal an searchRequest structure")
+		return "", errors.Wrap(err, "Cannot marshal a SearchRequest structure")
 	}
 
 	response, err := t.client.doWithContext(ctx,
@@ -515,10 +515,10 @@ func (t *topologyService) SaveA4CTopology(ctx context.Context, a4cCtx *TopologyE
 func (t *topologyService) GetTopologies(ctx context.Context, query string) ([]BasicTopologyInfo, error) {
 
 	getTopoJSON, err := json.Marshal(
-		searchRequest{
-			From:  "",
+		SearchRequest{
+			From:  0,
 			Query: query,
-			Size:  "",
+			Size:  0,
 		},
 	)
 

--- a/alien4cloud/user.go
+++ b/alien4cloud/user.go
@@ -1,0 +1,313 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// UserService is the interface to the service mamaging users and groups
+type UserService interface {
+	// CreateUser creates a user
+	CreateUser(ctx context.Context, createRequest CreateUserRequest) error
+	// UpdateUser updates a user parameters
+	UpdateUser(ctx context.Context, userName string, updateRequest UpdateUserRequest) error
+	// GetUser returns the parameters of a user whose name is provided in argument
+	GetUser(ctx context.Context, userName string) (*User, error)
+	// GetUsers returns the parameters of users whose names are provided in argument
+	GetUsers(ctx context.Context, userNames []string) ([]User, error)
+	// DeleteUser deletes a user
+	DeleteUser(ctx context.Context, userName string) error
+	// AddRole adds a role to a user
+	AddRole(ctx context.Context, userName, role string) Error
+	// RemoveRole removes a role that was granted user
+	RemoveRole(ctx context.Context, userName, role string) Error
+
+	// CreateGroup creates a group and returns its identifier
+	CreateGroup(ctx context.Context, createRequest CreateGroupRequest) (string, error)
+	// UpdateGroup updates a group parameters
+	UpdateGroup(ctx context.Context, groupID string, updateRequest UpdateGroupRequest) error
+	// GetGroup returns the parameters of a group whose identifier is provided in argument
+	GetGroup(ctx context.Context, groupID string) (Group, error)
+	// GetGroups returns the parameters of groups whose identifiers are provided in argument
+	GetGroups(ctx context.Context, groupIDs []string) ([]Group, error)
+	// DeleteGroup deletes a group
+	DeleteGroup(ctx context.Context, groupID string) error
+}
+
+type userService struct {
+	client restClient
+}
+
+// CreateUser creates a user
+func (u *userService) CreateUser(ctx context.Context, createRequest CreateUserRequest) error {
+
+	req, err := json.Marshal(createRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal create request")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"POST",
+		fmt.Sprintf("%s/users", a4CRestAPIPrefix),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "Unable to send request to create a user")
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// UpdateUser updates a user parameters
+func (u *userService) UpdateUser(ctx context.Context, userName string, updateRequest UpdateUserRequest) error {
+
+	req, err := json.Marshal(updateRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal update request")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"PUT",
+		fmt.Sprintf("%s/users/%s", a4CRestAPIPrefix, userName),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to update user %s", userName)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// GetUser returns the parameters of a user whose name is provided in argument
+func (u *userService) GetUser(ctx context.Context, userName string) (*User, error) {
+	response, err := u.client.doWithContext(ctx,
+		"GET",
+		fmt.Sprintf("%s/users/%s", a4CRestAPIPrefix, userName),
+		nil,
+		nil)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to send request to get user %s", userName)
+	}
+
+	var res struct {
+		Data  User  `json:"data,omitempty"`
+		Error Error `json:"error,omitempty"`
+	}
+
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Data, err
+}
+
+// GetUsers returns the parameters of a user whose name is provided in argument
+func (u *userService) GetUsers(ctx context.Context, userNames []string) ([]User, error) {
+	req, err := json.Marshal(userNames)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to marshal uner names")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"POST",
+		fmt.Sprintf("%s/users/getUsers", a4CRestAPIPrefix),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to send request to get users %v", userNames)
+	}
+
+	var res struct {
+		Data  []User `json:"data,omitempty"`
+		Error Error  `json:"error,omitempty"`
+	}
+
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Data, err
+}
+
+// DeleteUser deletes a user
+func (u *userService) DeleteUser(ctx context.Context, userName string) error {
+
+	response, err := u.client.doWithContext(ctx,
+		"DELETE",
+		fmt.Sprintf("%s/users/%s", a4CRestAPIPrefix, userName),
+		nil,
+		nil)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to delete user %s", userName)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// AddRole adds a role to a user
+func (u *userService) AddRole(ctx context.Context, userName, roleName string) error {
+
+	response, err := u.client.doWithContext(ctx,
+		"PUT",
+		fmt.Sprintf("%s/users/%s/roles/%s", a4CRestAPIPrefix, userName, roleName),
+		nil,
+		nil)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to add role %s to user %s", roleName, userName)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// RemoveRole removes a role to a user
+func (u *userService) RemoveRole(ctx context.Context, userName, roleName string) error {
+
+	response, err := u.client.doWithContext(ctx,
+		"DELETE",
+		fmt.Sprintf("%s/users/%s/roles/%s", a4CRestAPIPrefix, userName, roleName),
+		nil,
+		nil)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to delete role %s to user %s", roleName, userName)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// CreateGroup creates a group
+func (u *userService) CreateGroup(ctx context.Context, createRequest CreateGroupRequest) error {
+
+	req, err := json.Marshal(createRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal create request")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"POST",
+		fmt.Sprintf("%s/groups", a4CRestAPIPrefix),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "Unable to send request to create a group")
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// UpdateGroup updates a group parameters
+func (u *userService) UpdateGroup(ctx context.Context, groupID string, updateRequest UpdateGroupRequest) error {
+
+	req, err := json.Marshal(updateRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal update request")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"PUT",
+		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to update group %s", groupID)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}
+
+// GetGroup returns the parameters of a group whose name is provided in argument
+func (u *userService) GetGroup(ctx context.Context, groupID string) (*Group, error) {
+	response, err := u.client.doWithContext(ctx,
+		"GET",
+		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		nil,
+		nil)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to send request to get group %s", groupID)
+	}
+
+	var res struct {
+		Data  Group `json:"data,omitempty"`
+		Error Error `json:"error,omitempty"`
+	}
+
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Data, err
+}
+
+// GetGroups returns the parameters of a group whose name is provided in argument
+func (u *userService) GetGroups(ctx context.Context, groupIDs []string) ([]Group, error) {
+	req, err := json.Marshal(groupIDs)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to marshal uner names")
+	}
+
+	response, err := u.client.doWithContext(ctx,
+		"POST",
+		fmt.Sprintf("%s/groups/getGroups", a4CRestAPIPrefix),
+		req,
+		[]Header{contentTypeAppJSONHeader},
+	)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to send request to get groups %v", groupIDs)
+	}
+
+	var res struct {
+		Data  []Group `json:"data,omitempty"`
+		Error Error   `json:"error,omitempty"`
+	}
+
+	err = processA4CResponse(response, &res, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Data, err
+}
+
+// DeleteGroup deletes a group
+func (u *userService) DeleteGroup(ctx context.Context, groupID string) error {
+
+	response, err := u.client.doWithContext(ctx,
+		"DELETE",
+		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		nil,
+		nil)
+
+	if err != nil {
+		return errors.Wrapf(err, "Unable to send request to delete group %s", groupID)
+	}
+	return processA4CResponse(response, nil, http.StatusOK)
+}

--- a/alien4cloud/user.go
+++ b/alien4cloud/user.go
@@ -56,7 +56,10 @@ type userService struct {
 	client restClient
 }
 
-const userEndpointFormat = "%s/users/%s"
+const (
+	userEndpointFormat  = "%s/users/%s"
+	groupEndpointFormat = "%s/groups/%s"
+)
 
 // CreateUser creates a user
 func (u *userService) CreateUser(ctx context.Context, createRequest CreateUserRequest) error {
@@ -245,7 +248,7 @@ func (u *userService) UpdateGroup(ctx context.Context, groupID string, updateReq
 
 	response, err := u.client.doWithContext(ctx,
 		"PUT",
-		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		fmt.Sprintf(groupEndpointFormat, a4CRestAPIPrefix, groupID),
 		req,
 		[]Header{contentTypeAppJSONHeader},
 	)
@@ -260,7 +263,7 @@ func (u *userService) UpdateGroup(ctx context.Context, groupID string, updateReq
 func (u *userService) GetGroup(ctx context.Context, groupID string) (*Group, error) {
 	response, err := u.client.doWithContext(ctx,
 		"GET",
-		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		fmt.Sprintf(groupEndpointFormat, a4CRestAPIPrefix, groupID),
 		nil,
 		nil)
 
@@ -317,7 +320,7 @@ func (u *userService) DeleteGroup(ctx context.Context, groupID string) error {
 
 	response, err := u.client.doWithContext(ctx,
 		"DELETE",
-		fmt.Sprintf("%s/groups/%s", a4CRestAPIPrefix, groupID),
+		fmt.Sprintf(groupEndpointFormat, a4CRestAPIPrefix, groupID),
 		nil,
 		nil)
 

--- a/alien4cloud/user_test.go
+++ b/alien4cloud/user_test.go
@@ -1,0 +1,193 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_userService_TestCreateUser(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users`).Match([]byte(r.URL.Path)):
+			var req CreateUserRequest
+			rb, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("Failed to read request body %+v", r)
+			}
+			defer r.Body.Close()
+
+			err = json.Unmarshal(rb, &req)
+			if err != nil {
+				t.Errorf("Failed to unmarshal request body %+v", r)
+			}
+			if req.Username == "" {
+				var res struct {
+					Error Error `json:"error"`
+				}
+				res.Error.Code = http.StatusInternalServerError
+				res.Error.Message = "Method argument is invalid"
+				b, err := json.Marshal(&res)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+				} else {
+					w.WriteHeader(http.StatusNotImplemented)
+					_, _ = w.Write(b)
+				}
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx           context.Context
+		createRequest CreateUserRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"UndefinedUserName", args{context.Background(),
+			CreateUserRequest{Username: "", Password: "passwd"}}, true},
+		{"DefinedUserName", args{context.Background(),
+			CreateUserRequest{Username: "user1", Password: "passwd"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			if err := uServ.CreateUser(tt.args.ctx, tt.args.createRequest); (err != nil) != tt.wantErr {
+				t.Errorf("userService.CreateUser() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_userService_TestUpdateUser(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users/wronguser`).Match([]byte(r.URL.Path)):
+			defer r.Body.Close()
+
+			var res struct {
+				Error Error `json:"error"`
+			}
+			res.Error.Code = http.StatusGatewayTimeout
+			res.Error.Message = "User [wronguser] cannot be found"
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusGatewayTimeout)
+				_, _ = w.Write(b)
+			}
+		case regexp.MustCompile(`.*/users/.*`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx           context.Context
+		username      string
+		updateRequest UpdateUserRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"NotExistingUser", args{context.Background(), "wronguser",
+			UpdateUserRequest{FirstName: "unknown", Password: "passwd"}}, true},
+		{"ExistingUser", args{context.Background(), "user1",
+			UpdateUserRequest{FirstName: "user1", Password: "passwd"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			if err := uServ.UpdateUser(tt.args.ctx, tt.args.username, tt.args.updateRequest); (err != nil) != tt.wantErr {
+				t.Errorf("userService.CreateUser() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_userService_TestGetUser(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users/expectedUser`).Match([]byte(r.URL.Path)):
+			defer r.Body.Close()
+
+			var res struct {
+				Data  User  `json:"data"`
+				Error Error `json:"error"`
+			}
+			res.Data.Username = "expectedUser"
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(b)
+			}
+		case regexp.MustCompile(`.*/users/.*`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx      context.Context
+		username string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"ExistingUser", args{context.Background(), "expectedUser"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			userResp, err := uServ.GetUser(tt.args.ctx, tt.args.username)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("userService.GetUser() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err == nil {
+				assert.Equal(t, tt.args.username, userResp.Username, "Unexpected result for GetUser: %+v", userResp)
+			}
+
+		})
+	}
+}

--- a/alien4cloud/user_test.go
+++ b/alien4cloud/user_test.go
@@ -191,3 +191,166 @@ func Test_userService_TestGetUser(t *testing.T) {
 		})
 	}
 }
+
+func Test_userService_TestGetUsers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users/getUsers`).Match([]byte(r.URL.Path)):
+
+			var req []string
+			rb, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("Failed to read request body %+v", r)
+			}
+			defer r.Body.Close()
+
+			err = json.Unmarshal(rb, &req)
+			if err != nil {
+				t.Errorf("Failed to unmarshal request body %+v", r)
+			}
+
+			defer r.Body.Close()
+
+			var res struct {
+				Data  []User `json:"data"`
+				Error Error  `json:"error"`
+			}
+
+			if len(req) == 0 {
+				res.Error.Code = http.StatusNotImplemented
+				res.Error.Message = "usernames cannot be null or empty"
+				w.WriteHeader(http.StatusNotImplemented)
+			} else {
+				users := make([]User, len(req))
+				for i := 0; i < len(req); i++ {
+					users[i].Username = req[i]
+				}
+				res.Data = users
+				w.WriteHeader(http.StatusOK)
+			}
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				_, _ = w.Write(b)
+			}
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx       context.Context
+		usernames []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"NoUser", args{context.Background(), []string{}}, true},
+		{"Users", args{context.Background(), []string{"user1", "user2"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			userResp, err := uServ.GetUsers(tt.args.ctx, tt.args.usernames)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("userService.GetUser() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err == nil {
+				assert.Equal(t, len(tt.args.usernames), len(userResp), "Unexpected result for GetUsers: %+v", userResp)
+			}
+		})
+	}
+}
+
+func Test_userService_TestDeleteUser(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users/.*`).Match([]byte(r.URL.Path)):
+			defer r.Body.Close()
+
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx      context.Context
+		userName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"DeleteUserUserName", args{context.Background(), "existingUser"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			if err := uServ.DeleteUser(tt.args.ctx, tt.args.userName); (err != nil) != tt.wantErr {
+				t.Errorf("userService.DeleteUser() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_userService_TestAddRemoveRole(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/users/.*/roles/badrole`).Match([]byte(r.URL.Path)):
+			defer r.Body.Close()
+
+			var res struct {
+				Error Error `json:"error"`
+			}
+			res.Error.Code = http.StatusGatewayTimeout
+			res.Error.Message = "Role [badrole] cannot be found"
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusGatewayTimeout)
+				_, _ = w.Write(b)
+			}
+		case regexp.MustCompile(`.*/users/.*/roles/.*`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("Unexpected request %s", r.URL.Path)
+		}
+	}))
+
+	type args struct {
+		ctx      context.Context
+		username string
+		rolename string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"BadRole", args{context.Background(), "user1", "badrole"}, true},
+		{"CorrectRole", args{context.Background(), "user1", "ROLE_APPLICATIONS_MANAGER"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uServ := &userService{
+				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+			}
+			if err := uServ.AddRole(tt.args.ctx, tt.args.username, tt.args.rolename); (err != nil) != tt.wantErr {
+				t.Errorf("userService.AddRole() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := uServ.RemoveRole(tt.args.ctx, tt.args.username, tt.args.rolename); (err != nil) != tt.wantErr {
+				t.Errorf("userService.RemoveRole() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/alien4cloud/user_test.go
+++ b/alien4cloud/user_test.go
@@ -32,7 +32,7 @@ func Test_userService_TestCreateUser(t *testing.T) {
 		defer r.Body.Close()
 		switch {
 		case regexp.MustCompile(`.*/users`).Match([]byte(r.URL.Path)):
-			var req CreateUserRequest
+			var req CreateUpdateUserRequest
 			rb, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Failed to read request body %+v", r)
@@ -42,7 +42,7 @@ func Test_userService_TestCreateUser(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to unmarshal request body %+v", r)
 			}
-			if req.Username == "" {
+			if req.UserName == "" {
 				var res struct {
 					Error Error `json:"error"`
 				}
@@ -65,7 +65,7 @@ func Test_userService_TestCreateUser(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		createRequest CreateUserRequest
+		createRequest CreateUpdateUserRequest
 	}
 	tests := []struct {
 		name    string
@@ -73,9 +73,9 @@ func Test_userService_TestCreateUser(t *testing.T) {
 		wantErr bool
 	}{
 		{"UndefinedUserName", args{context.Background(),
-			CreateUserRequest{Username: "", Password: "passwd"}}, true},
+			CreateUpdateUserRequest{UserName: "", Password: "passwd"}}, true},
 		{"DefinedUserName", args{context.Background(),
-			CreateUserRequest{Username: "user1", Password: "passwd"}}, false},
+			CreateUpdateUserRequest{UserName: "user1", Password: "passwd"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,7 +117,7 @@ func Test_userService_TestUpdateUser(t *testing.T) {
 	type args struct {
 		ctx           context.Context
 		username      string
-		updateRequest UpdateUserRequest
+		updateRequest CreateUpdateUserRequest
 	}
 	tests := []struct {
 		name    string
@@ -125,9 +125,9 @@ func Test_userService_TestUpdateUser(t *testing.T) {
 		wantErr bool
 	}{
 		{"NotExistingUser", args{context.Background(), "wronguser",
-			UpdateUserRequest{FirstName: "unknown", Password: "passwd"}}, true},
+			CreateUpdateUserRequest{FirstName: "unknown", Password: "passwd"}}, true},
 		{"ExistingUser", args{context.Background(), "user1",
-			UpdateUserRequest{FirstName: "user1", Password: "passwd"}}, false},
+			CreateUpdateUserRequest{FirstName: "user1", Password: "passwd"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,7 +150,7 @@ func Test_userService_TestGetUser(t *testing.T) {
 		}
 		switch {
 		case regexp.MustCompile(`.*/users/expectedUser`).Match([]byte(r.URL.Path)):
-			res.Data.Username = "expectedUser"
+			res.Data.UserName = "expectedUser"
 			w.WriteHeader(http.StatusOK)
 
 		case regexp.MustCompile(`.*/users/.*`).Match([]byte(r.URL.Path)):
@@ -188,7 +188,7 @@ func Test_userService_TestGetUser(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("userService.GetUser() error = %v, wantErr %v", err, tt.wantErr)
 			} else if err == nil {
-				assert.Equal(t, tt.args.username, userResp.Username, "Unexpected result for GetUser: %+v", userResp)
+				assert.Equal(t, tt.args.username, userResp.UserName, "Unexpected result for GetUser: %+v", userResp)
 			}
 
 		})
@@ -224,7 +224,7 @@ func Test_userService_TestGetUsers(t *testing.T) {
 			} else {
 				users := make([]User, len(req))
 				for i := 0; i < len(req); i++ {
-					users[i].Username = req[i]
+					users[i].UserName = req[i]
 				}
 				res.Data = users
 				w.WriteHeader(http.StatusOK)
@@ -300,7 +300,7 @@ func Test_userService_TestSearchUsers(t *testing.T) {
 			users := make([]User, nbUsers)
 			idx := 0
 			for i := req.From; i < nbUsers+req.From; i++ {
-				users[idx].Username = fmt.Sprintf("User%d", i)
+				users[idx].UserName = fmt.Sprintf("User%d", i)
 				idx++
 			}
 			res.Data.Data = users
@@ -341,7 +341,7 @@ func Test_userService_TestSearchUsers(t *testing.T) {
 			} else {
 				assert.Equal(t, 10, totalNb, "Unexpected total number of users returned by SearchUsers: %d", totalNb)
 				assert.Equal(t, tt.wantSize, len(userResp), "Unexpected number of users returned by SearchUsers: %d", len(userResp))
-				assert.Equal(t, tt.firstUser, userResp[0].Username, "Unexpected first user returned by SearchUsers: %s", userResp[0].Username)
+				assert.Equal(t, tt.firstUser, userResp[0].UserName, "Unexpected first user returned by SearchUsers: %s", userResp[0].UserName)
 			}
 		})
 	}
@@ -441,7 +441,7 @@ func Test_userService_TestCreateGroup(t *testing.T) {
 		defer r.Body.Close()
 		switch {
 		case regexp.MustCompile(`.*/groups`).Match([]byte(r.URL.Path)):
-			var req CreateGroupRequest
+			var req Group
 			rb, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Failed to read request body %+v", r)
@@ -478,7 +478,7 @@ func Test_userService_TestCreateGroup(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		createRequest CreateGroupRequest
+		createRequest Group
 	}
 	tests := []struct {
 		name    string
@@ -486,9 +486,9 @@ func Test_userService_TestCreateGroup(t *testing.T) {
 		wantErr bool
 	}{
 		{"UndefinedGroupName", args{context.Background(),
-			CreateGroupRequest{Name: "", Roles: []string{ROLE_ARCHITECT, ROLE_APPLICATIONS_MANAGER}}}, true},
+			Group{Name: "", Roles: []string{ROLE_ARCHITECT, ROLE_APPLICATIONS_MANAGER}}}, true},
 		{"DefinedGroupName", args{context.Background(),
-			CreateGroupRequest{Name: "newgroupname", Roles: []string{ROLE_ARCHITECT, ROLE_APPLICATIONS_MANAGER}}}, false},
+			Group{Name: "newgroupname", Roles: []string{ROLE_ARCHITECT, ROLE_APPLICATIONS_MANAGER}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -534,7 +534,7 @@ func Test_userService_TestUpdateGroup(t *testing.T) {
 	type args struct {
 		ctx           context.Context
 		username      string
-		updateRequest UpdateGroupRequest
+		updateRequest Group
 	}
 	tests := []struct {
 		name    string
@@ -542,9 +542,9 @@ func Test_userService_TestUpdateGroup(t *testing.T) {
 		wantErr bool
 	}{
 		{"WrongGroup", args{context.Background(), "wronggroup",
-			UpdateGroupRequest{Name: "unknown", Email: "passwd"}}, true},
+			Group{Name: "unknown", Email: "passwd"}}, true},
 		{"ExistingGroup", args{context.Background(), "user1",
-			UpdateGroupRequest{Email: "group1@acme.com"}}, false},
+			Group{Email: "group1@acme.com"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/examples/create-user/README.md
+++ b/examples/create-user/README.md
@@ -1,0 +1,31 @@
+# Create a user
+
+This example shows how the Alien4Cloud go client can be used to create a user.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd create-user
+go build -o create.test
+```
+
+Now, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of a user having the administrator
+* user properties
+
+For example:
+
+```bash
+./create.test -url https://1.2.3.4:8088 \
+              -user adminuser \
+              -password mypasswd \
+              -username mynewuser \
+              -userpassword mynewuserpassword \
+              -firstname John \
+              -lastname Doe \
+              -email "john.doe@acme.com" \
+              -role APPLICATIONS_MANAGER -role ARCHITECT
+```

--- a/examples/create-user/main.go
+++ b/examples/create-user/main.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, username, firstname, lastname, email, userpassword string
+
+type stringArrayFlags []string
+
+var roles stringArrayFlags
+
+func (i *stringArrayFlags) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+func (i *stringArrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "Admin user used to connect to Alien4Cloud")
+	flag.StringVar(&password, "password", "changeme", "Admin password")
+	flag.StringVar(&username, "username", "", "name of user to create")
+	flag.StringVar(&userpassword, "userpassword", "", "name of user to create")
+	flag.StringVar(&firstname, "firstname", "", "name of user to create")
+	flag.StringVar(&lastname, "lastname", "", "name of user to create")
+	flag.StringVar(&email, "email", "", "name of user to create")
+
+	flag.Var(&roles, "role", "Role to add (repeat this flag several times to add several roles")
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	createRequest := alien4cloud.CreateUpdateUserRequest{
+		UserName: username, FirstName: firstname, LastName: lastname, Email: email, Roles: roles,
+		Password: userpassword,
+	}
+	err = client.UserService().CreateUser(ctx, createRequest)
+	if err != nil {
+		log.Panic(err)
+	}
+	fmt.Printf("User %s created.\n", username)
+}

--- a/examples/get-user/README.md
+++ b/examples/get-user/README.md
@@ -1,0 +1,26 @@
+# Gets a user
+
+This example shows how the Alien4Cloud go client can be used to get a user parameters.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd get-user
+go build -o getuser.test
+```
+
+Now, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of a user having the administrator
+* user name for which to get parameters
+
+For example:
+
+```bash
+./getuser.test -url https://1.2.3.4:8088 \
+               -user adminuser \
+               -password mypasswd \
+               -username myuser
+```

--- a/examples/get-user/main.go
+++ b/examples/get-user/main.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, username string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "Admin user used to connect to Alien4Cloud")
+	flag.StringVar(&password, "password", "changeme", "Admin password")
+	flag.StringVar(&username, "username", "", "name of user to get")
+
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	userDetails, err := client.UserService().GetUser(ctx, username)
+	if err != nil {
+		log.Panic(err)
+	}
+	if userDetails.UserName == "" {
+		fmt.Printf("No such user %s\n", username)
+	} else {
+		fmt.Printf("User      : %s\n", userDetails.UserName)
+		fmt.Printf("First name: %s\n", userDetails.FirstName)
+		fmt.Printf("Last name : %s\n", userDetails.LastName)
+		fmt.Printf("Email     : %s\n", userDetails.Email)
+		fmt.Printf("Roles     : %v\n", userDetails.Roles)
+	}
+}

--- a/examples/search-users/README.md
+++ b/examples/search-users/README.md
@@ -1,0 +1,30 @@
+# Search for users
+
+This example shows how the Alien4Cloud go client can be used to search for users.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd search-users
+go build -o search.test
+```
+
+Now, run this example providing in arguments:
+* the Alien4Cloud URL
+* credentials of a user having the administrator
+* search properties (optional):
+  * from: start index of user to return
+  * size: maximum number of users to return
+  * query: string to search
+
+For example:
+
+```bash
+./search.test -url https://1.2.3.4:8088 \
+           -user myuser \
+           -password mypasswd \
+           -size 10
+```
+This will return the first 10 users, as well as the total number of users.

--- a/examples/search-users/main.go
+++ b/examples/search-users/main.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password, query string
+var from, size int
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+	flag.StringVar(&query, "query", "", "string to query")
+	flag.IntVar(&from, "from", 0, "Index from which to return users")
+	flag.IntVar(&size, "size", 0, "Maximum number of users to return")
+
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	searchRequest := alien4cloud.SearchRequest{
+		From:  from,
+		Size:  size,
+		Query: query,
+	}
+	users, totalNumber, err := client.UserService().SearchUsers(ctx, searchRequest)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for _, user := range users {
+		fmt.Printf("User %s, roles: %v\n", user.Username, user.Roles)
+	}
+	fmt.Printf("Total number of users: %d\n", totalNumber)
+}


### PR DESCRIPTION
Added a new service UserService allowing to perform Create Read Update Delete operations on users and groups from Alien4Cloud REST APIs described in this section: http://alien4cloud.github.io/#/documentation/2.2.0/rest/overview_admin-user-api.html
Added an example using this service `SearchUsers` function

Closes #30 