### PR TITLE
Expose functions to call arbitrary endpoints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         tar xzf gotestsum.tgz
         rm -f gotestsum.tgz
     - name: Test
-      uses: docker://golang:1-stretch
+      uses: docker://golang:1
       with:
         args: /bin/bash -c "./gotestsum --jsonfile tests-reports.json  -- -count=1 -coverprofile coverage-sonar.out -coverpkg=./... $(go list ./... | grep -v '/examples/')"
       env:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ Go client for [Alien4Cloud](https://github.com/alien4cloud/alien4cloud) REST API
 
 See examples describing how to:
 
-* [create and deploy an application](examples/create-deploy-app/README.md)
-* [run a workflow](examples/run-workflow/README.md)
-* [undeploy and delete an application](examples/undeploy-delete-app/README.md)
+* Catalog Management:
+  * [upload a CSAR](examples/upload-csar/README.md)
+  * [get available inputs of a topology template](examples/get-input-parameters/README.md)
+* Application Management:
+  * [create and deploy an application](examples/create-deploy-app/README.md)
+  * [get information on a given application using its ID](examples/get-application-by-id/README.md)
+  * [set application inputs](examples/set-input-parameters/README.md)
+  * [get inputs used for a given deployment](examples/get-deployment-input-parameters/README.md)
+  * [run a workflow](examples/run-workflow/README.md)
+  * [get status for a workflow](examples/get-workflow-status/README.md)
+  * [undeploy and delete an application](examples/undeploy-delete-app/README.md)
+* Users/Groups Management:
+  * [create a user](examples/create-user/README.md)
+  * [get user information](examples/get-user/README.md)
+  * [search for users](examples/search-users/README.md)
+* Operations for experts:
+  * [call arbitrary API endpoint using raw requests](examples/raw-request/README.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # alien4cloud-go-client
 
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/alien4cloud/alien4cloud-go-client/v2)](https://pkg.go.dev/github.com/alien4cloud/alien4cloud-go-client/v2) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alien4cloud_alien4cloud-go-client&metric=alert_status)](https://sonarcloud.io/dashboard?id=alien4cloud_alien4cloud-go-client)
+
 Go client for [Alien4Cloud](https://github.com/alien4cloud/alien4cloud) REST API.
 
 See examples describing how to:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alien4cloud-go-client
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/alien4cloud/alien4cloud-go-client/v2)](https://pkg.go.dev/github.com/alien4cloud/alien4cloud-go-client/v2) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alien4cloud_alien4cloud-go-client&metric=alert_status)](https://sonarcloud.io/dashboard?id=alien4cloud_alien4cloud-go-client)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/alien4cloud/alien4cloud-go-client/v2)](https://pkg.go.dev/github.com/alien4cloud/alien4cloud-go-client/v2) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alien4cloud_alien4cloud-go-client&metric=alert_status)](https://sonarcloud.io/dashboard?id=alien4cloud_alien4cloud-go-client) [![Go Report Card](https://goreportcard.com/badge/github.com/alien4cloud/alien4cloud-go-client)](https://goreportcard.com/report/github.com/alien4cloud/alien4cloud-go-client) [![license](https://img.shields.io/github/license/alien4cloud/alien4cloud-go-client.svg)](https://github.com/alien4cloud/alien4cloud-go-client/blob/master/LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 Go client for [Alien4Cloud](https://github.com/alien4cloud/alien4cloud) REST API.
 

--- a/alien4cloud/alien4cloud.go
+++ b/alien4cloud/alien4cloud.go
@@ -46,12 +46,12 @@ type Client interface {
 	CatalogService() CatalogService
 	UserService() UserService
 
-	// NewRequest allows to create a custom request to be send to Alien4Cloud
+	// NewRequest allows to create a custom request to be sent to Alien4Cloud
 	// given a Context, method, url path and optional body.
 	//
 	// If the provided body is also an io.Closer, the Client Do function will automatically
 	// close it.
-	// The body need to be a ReadSeeker in order to rewind request on retries.
+	// The body needs to be a ReadSeeker in order to rewind request on retries.
 	//
 	// NewRequestWithContext returns a Request suitable for use with Client.Do
 	//
@@ -84,7 +84,7 @@ type Client interface {
 // It allows to perform actions based on the given response before re-sending a request.
 // A typical usecase is to automatically call the Client.Login() function when receiving a 403 Forbidden response.
 //
-// It is possible to alter the request to be send by returning an updated request. But in most cases
+// It is possible to alter the request to be sent by returning an updated request. But in most cases
 // the given original request can safely be returned as it. This framework take care of rewinding the request body
 // before giving it to retry functions.
 //

--- a/alien4cloud/alien4cloud_bare.go
+++ b/alien4cloud/alien4cloud_bare.go
@@ -1,0 +1,152 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func (c *a4cClient) NewRequest(ctx context.Context, method, urlStr string, body io.ReadSeeker) (*http.Request, error) {
+	var contentLength int64
+	switch v := body.(type) {
+	case *bytes.Reader:
+		contentLength = int64(v.Len())
+	case *strings.Reader:
+		contentLength = int64(v.Len())
+	}
+
+	if body != nil {
+		body = &nopCloserReadSeeker{body}
+	}
+	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentLength > 0 {
+		request.ContentLength = contentLength
+	}
+
+	// Add default headers
+	request.Header.Add(contentTypeHeaderName, appJSONHeader)
+	request.Header.Add(acceptHeaderName, appJSONHeader)
+	return request, nil
+}
+
+func (c *a4cClient) Do(request *http.Request, retries ...Retry) (*http.Response, error) {
+	// Close request body if underling reader allows it.
+	var ncrsBody *nopCloserReadSeeker
+	if request.Body != nil {
+		var ok bool
+		ncrsBody, ok = request.Body.(*nopCloserReadSeeker)
+		if ok {
+			c, okCloser := ncrsBody.ReadSeeker.(io.Closer)
+			if okCloser {
+				defer c.Close()
+			}
+		}
+	}
+
+	// always add retry forbidden errors
+	retriesWithDefaults := append(retries, retryForbidden)
+
+	response, err := c.client.Do(request)
+	if err != nil {
+		return response, err
+	}
+
+	for _, retry := range retriesWithDefaults {
+		if ncrsBody != nil {
+			// Restart reading request body from the beginning
+			ncrsBody.Seek(0, io.SeekStart)
+		}
+		req, err := retry(c, request, response)
+		if err != nil {
+			return response, err
+		}
+		if req != nil {
+			// Before retrying we need to fully read and close this response
+			discardHTTPResponseBody(response)
+			return c.Do(req, retries...)
+		}
+	}
+
+	return response, nil
+}
+
+// ReadA4CResponse is an helper function that allow to fully read and close a response body and
+// unmarshal its json content into a provided data structure.
+// If response status code is greather or equal to 400 it automatically parse an error response and
+// returns it as a non-nil error.
+func ReadA4CResponse(response *http.Response, data interface{}) error {
+	defer response.Body.Close()
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot read the response from Alien4Cloud")
+	}
+	if response.StatusCode >= 400 {
+		var res struct {
+			Error Error `json:"error"`
+		}
+		err = json.Unmarshal(responseBody, &res)
+		if err != nil {
+			return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud error response")
+		}
+		return errors.New(res.Error.Message)
+	}
+	if data != nil {
+		err = json.Unmarshal(responseBody, &data)
+	}
+	return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud response")
+}
+
+func retryForbidden(client Client, request *http.Request, response *http.Response) (*http.Request, error) {
+	if response.StatusCode != http.StatusForbidden {
+		// Nothing to retry
+		return nil, nil
+	}
+	err := client.Login(request.Context())
+	return request, err
+}
+
+type nopCloserReadSeeker struct {
+	io.ReadSeeker
+}
+
+func (nc nopCloserReadSeeker) Close() error {
+	return nil
+}
+
+func (nc nopCloserReadSeeker) Read(p []byte) (n int, err error) {
+	return nc.ReadSeeker.Read(p)
+}
+
+func (nc nopCloserReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return nc.ReadSeeker.Seek(offset, whence)
+}
+
+func discardHTTPResponseBody(response *http.Response) error {
+	defer response.Body.Close()
+	_, err := io.Copy(ioutil.Discard, response.Body)
+	return errors.Wrap(err, "failed to fully read and discard response body")
+}

--- a/alien4cloud/alien4cloud_bare_test.go
+++ b/alien4cloud/alien4cloud_bare_test.go
@@ -1,0 +1,115 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_reties(t *testing.T) {
+	expectedBody := `
+all my content
+go
+there
+`
+	loginCalled := new(bool)
+	retryCalled := new(bool)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if regexp.MustCompile(`.*/login`).Match([]byte(r.URL.Path)) {
+			*loginCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+
+		if !*loginCalled {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code": 403,"message":"login required"}}`))
+			return
+		}
+
+		switch {
+		case regexp.MustCompile(`.*/retry`).Match([]byte(r.URL.Path)):
+			*retryCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":"retried"}`))
+			return
+		default:
+			if !*retryCalled {
+				w.WriteHeader(http.StatusGatewayTimeout)
+				_, _ = w.Write([]byte(`{"error":{"code": 504,"message":"This error should be retried"}}`))
+				return
+			}
+
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf(`{"error":{"code": 500,"message": %q}}`, err.Error())))
+				return
+			}
+			if string(b) != expectedBody {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf(`{"error":{"code": 500,"message": %q}}`, "not the expecting body: '"+string(b)+"'")))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":"success"}`))
+			return
+		}
+	}))
+
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "a", "a", "", false)
+	assert.NilError(t, err)
+	req, err := client.NewRequest(context.Background(), "POST", "/somepath", strings.NewReader(expectedBody))
+	assert.NilError(t, err)
+
+	// Checks that default retry function to re-login is call then this retry function should be called
+	myRetryFn := func(c Client, request *http.Request, response *http.Response) (*http.Request, error) {
+		if response.StatusCode != http.StatusGatewayTimeout {
+			return nil, nil
+		}
+		r, err := c.NewRequest(context.Background(), "GET", "/retry", nil)
+		if err != nil {
+			return request, err
+		}
+		resp, err := c.Do(r)
+		if resp != nil {
+			err = ReadA4CResponse(resp, nil)
+		}
+		return request, err
+	}
+
+	respData := new(struct {
+		Data string
+	})
+
+	resp, err := client.Do(req, myRetryFn)
+	ReadA4CResponse(resp, respData)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, respData.Data, "success")
+
+}

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -132,6 +132,10 @@ type Header struct {
 var contentTypeAppJSONHeader = Header{"Content-Type", "application/json"}
 var acceptAppJSONHeader = Header{"Accept", "application/json"}
 
+const contentTypeHeaderName = "Content-Type"
+const acceptHeaderName = "Accept"
+const appJSONHeader = "application/json"
+
 // Error is the representation of an A4C error
 type Error struct {
 	Code    int    `json:"code"`

--- a/alien4cloud/application.go
+++ b/alien4cloud/application.go
@@ -359,6 +359,6 @@ func (a *applicationService) GetDeploymentTopology(ctx context.Context, appID st
 	if err != nil {
 		return res, errors.Wrapf(err, "Cannot get the deployment topology content for application '%s' on environment '%s'", appID, envID)
 	}
-
-	return res, errors.Wrapf(ReadA4CResponse(resp, res), "Cannot get the deployment topology content for application '%s' on environment '%s'", appID, envID)
+	err = ReadA4CResponse(resp, res)
+	return res, errors.Wrapf(err, "Cannot get the deployment topology content for application '%s' on environment '%s'", appID, envID)
 }

--- a/alien4cloud/application_test.go
+++ b/alien4cloud/application_test.go
@@ -62,7 +62,7 @@ func Test_applicationService_IsApplicationExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			a := &applicationService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			found, err := a.IsApplicationExist(tt.args.ctx, tt.args.appID)
@@ -93,7 +93,7 @@ func Test_applicationService_GetApplicationsID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			a := &applicationService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			results, err := a.GetApplicationsID(tt.args.ctx, tt.args.appID)
@@ -140,7 +140,7 @@ func Test_applicationService_GetApplicationByID(t *testing.T) {
 		t.Run(tt.id, func(t *testing.T) {
 
 			a := &applicationService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			app, err := a.GetApplicationByID(tt.args.ctx, tt.args.appID)

--- a/alien4cloud/catalog_test.go
+++ b/alien4cloud/catalog_test.go
@@ -93,7 +93,7 @@ func Test_catalogService_UploadCSAR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := &catalogService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			got, err := cs.UploadCSAR(tt.args.ctx, tt.args.csar, tt.args.workspace)
 			if (err != nil) != tt.wantErr {

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -101,8 +101,7 @@ func (d *deploymentService) GetLocationsMatching(ctx context.Context, topologyID
 	}
 	response, err := d.client.Do(request)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get locations matching topology for application '%s' in '%s' environment",
-			topologyID, envID)
+		return nil, errors.Wrapf(err, "Failed to get locations matching topology for application '%s' in '%s' environment", topologyID, envID)
 	}
 	err = ReadA4CResponse(response, &res)
 	return res.Data, errors.Wrapf(err, "Cannot convert the body response to request on locations matching topology '%s' in '%s' environment",
@@ -507,7 +506,7 @@ func (d *deploymentService) GetOutputAttributes(ctx context.Context, application
 
 // GetAttributesValue returns the application deployment attributes for the first instance of the specified nodeName
 func (d *deploymentService) GetAttributesValue(ctx context.Context, applicationID string, environmentID string, nodeName string, requestedAttributesName []string) (map[string]string, error) {
-	return d.getInstanceAttributesValue(ctx, applicationID, environmentID, nodeName, "0", requestedAttributesName)
+	return d.GetInstanceAttributesValue(ctx, applicationID, environmentID, nodeName, "0", requestedAttributesName)
 }
 
 // GetInstanceAttributesValue returns the application deployment attributes for a specified nodeName and instanceName

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -116,8 +116,7 @@ func (d *deploymentService) DeployApplication(ctx context.Context, appID string,
 	// get locations matching this application
 	topologyID, err := d.client.topologyService.GetTopologyID(ctx, appID, envID)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to get application topology for app %s and env %s",
-			appID, envID)
+		return errors.Wrapf(err, "Unable to get application topology for app %s and env %s", appID, envID)
 	}
 
 	locationsMatch, err := d.GetLocationsMatching(ctx, topologyID, envID)

--- a/alien4cloud/deployment_execution_test.go
+++ b/alien4cloud/deployment_execution_test.go
@@ -85,7 +85,7 @@ func Test_deploymentService_GetExecutions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			got, got1, err := d.GetExecutions(tt.args.ctx, tt.args.deploymentID, tt.args.query, tt.args.from, tt.args.size)
 			if (err != nil) != tt.wantErr {
@@ -100,7 +100,7 @@ func Test_deploymentService_GetExecutions(t *testing.T) {
 	ctx, cf := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cf()
 	d := &deploymentService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 	got, got1, err := d.GetExecutions(ctx, "internalerror", "", 0, 10)
 	assert.ErrorContains(t, err, "context deadline exceeded")

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -75,6 +75,7 @@ func Test_deploymentService_DeployApplication(t *testing.T) {
 			return
 		case regexp.MustCompile(`.*/applications/deployment`).Match([]byte(r.URL.Path)):
 			b, err := ioutil.ReadAll(r.Body)
+			defer r.Body.Close()
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				return

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -69,7 +69,7 @@ func Test_deploymentService_UpdateApplication(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			if err := d.UpdateApplication(tt.args.ctx, tt.args.appID, tt.args.envID); (err != nil) != tt.wantErr {
@@ -81,7 +81,7 @@ func Test_deploymentService_UpdateApplication(t *testing.T) {
 	cancelableCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancelFn()
 	d := &deploymentService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 
 	if err := d.UpdateApplication(cancelableCtx, "cancel", "envID"); err == nil {
@@ -138,7 +138,7 @@ func Test_deploymentService_WaitUntilStateIs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			got, err := d.WaitUntilStateIs(tt.args.ctx, tt.args.appID, tt.args.envID, tt.args.statuses...)
 			if (err != nil) != tt.wantErr {
@@ -154,7 +154,7 @@ func Test_deploymentService_WaitUntilStateIs(t *testing.T) {
 	cancelableCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancelFn()
 	d := &deploymentService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 
 	if _, err := d.WaitUntilStateIs(cancelableCtx, "cancel", "envID", ApplicationUpdated); err == nil {
@@ -212,7 +212,7 @@ func Test_deploymentService_GetDeploymentStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			got, err := d.GetDeploymentStatus(tt.args.ctx, tt.args.appID, tt.args.envID)
 			if (err != nil) != tt.wantErr {
@@ -228,7 +228,7 @@ func Test_deploymentService_GetDeploymentStatus(t *testing.T) {
 	cancelableCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancelFn()
 	d := &deploymentService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 
 	if _, err := d.WaitUntilStateIs(cancelableCtx, "cancel", "envID", ApplicationUpdated); err == nil {
@@ -309,7 +309,7 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			got, err := d.RunWorkflow(tt.args.ctx, tt.args.a4cAppID, tt.args.a4cEnvID, tt.args.workflowName, tt.args.timeout)
 			if (err != nil) != tt.wantErr {
@@ -323,7 +323,7 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 	cancelableCtx, cancelFn := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancelFn()
 	d := &deploymentService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 
 	_, err := d.RunWorkflow(cancelableCtx, "cancel", "envID", "wf", 500*time.Millisecond)
@@ -396,7 +396,7 @@ func Test_deploymentService_UpdateDeploymentSetup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			err := d.UpdateDeploymentTopology(tt.args.ctx, tt.args.appID, tt.args.envID,
@@ -466,7 +466,7 @@ func Test_deploymentService_UploadDeploymentInputArtifact(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			d := &deploymentService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			f, err := ioutil.TempFile("", tt.name)

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func Test_deploymentService_DeployApplication(t *testing.T) {
-	closeCh := make(chan struct{})
-	defer close(closeCh)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case regexp.MustCompile(`.*/topologies/TopologyID/locations.*`).Match([]byte(r.URL.Path)):

--- a/alien4cloud/doc.go
+++ b/alien4cloud/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package alien4cloud provides a client for using the [Alien4Cloud](https://alien4cloud.github.io) API.
+
+Usage:
+	import "github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/alien4cloud/alien4cloud-go-client/alien4cloud"       // with go modules disabled
+
+Then you could create a client and use the different services exposed by the Alien4Cloud API:
+
+	client, err := alien4cloud.NewClient(url, user, password, caFile, skipSecure)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	userDetails, err := client.UserService().GetUser(ctx, username)
+
+NOTE: Using the https://pkg.go.dev/context package, allows to easily pass cancelation signals and deadlines
+to API calls for handling a request.
+
+For more sample code snippets, see the https://github.com/lien4cloud/alien4cloud-go-client/tree/master/examples directory.
+
+*/
+package alien4cloud

--- a/alien4cloud/event_test.go
+++ b/alien4cloud/event_test.go
@@ -47,7 +47,7 @@ func Test_eventService_GetEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			evService := &eventService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			_, nbEvents, err := evService.GetEventsForApplicationEnvironment(tt.args.ctx, tt.args.envID, 0, 10)

--- a/alien4cloud/log_test.go
+++ b/alien4cloud/log_test.go
@@ -1,0 +1,140 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_deploymentService_GetLogsOfApplication(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/deployments/search`).Match([]byte(r.URL.Path)):
+			envID := r.URL.Query().Get("environmentId")
+			var deploymentListResponse struct {
+				Data struct {
+					Data []struct {
+						Deployment Deployment
+					}
+					TotalResults int `json:"totalResults"`
+				} `json:"data"`
+			}
+			deploymentListResponse.Data.TotalResults = 1
+			deploymentListResponse.Data.Data = []struct {
+				Deployment Deployment
+			}{
+				{
+					Deployment{
+						ID: envID,
+					},
+				},
+			}
+
+			b, err := json.Marshal(&deploymentListResponse)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+		case regexp.MustCompile(`.*/deployment/logs/search`).Match([]byte(r.URL.Path)):
+
+			var lsr logsSearchRequest
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			err = json.Unmarshal(b, &lsr)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if lsr.Filters.DeploymentID[0] == "error" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			var res struct {
+				Data struct {
+					Data         []Log `json:"data"`
+					From         int   `json:"from"`
+					To           int   `json:"to"`
+					TotalResults int   `json:"totalResults"`
+				} `json:"data"`
+			}
+			res.Data.TotalResults = 3
+			res.Data.Data = []Log{
+				{
+					Content: "somelog",
+					ID:      "1",
+				},
+				{
+					Content: "somemorelog",
+					ID:      "2",
+				},
+				{
+					Content: "someotherlog",
+					ID:      "3",
+				},
+			}
+			b, err = json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+		}
+
+	}))
+
+	type args struct {
+		ctx        context.Context
+		appID      string
+		envID      string
+		logFilters LogFilter
+		fromIndex  int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"GetLogsOfApplicationOK", args{context.Background(), "normal", "envID", LogFilter{}, 0}, false},
+		{"GetLogsOfApplicationError", args{context.Background(), "error", "error", LogFilter{}, 0}, true},
+	}
+	client, err := NewClient(ts.URL, "", "", "", true)
+	assert.NilError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			_, _, err := client.LogService().GetLogsOfApplication(tt.args.ctx, tt.args.appID, tt.args.envID, tt.args.logFilters, tt.args.fromIndex)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deploymentService.GetLogsOfApplication() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+		})
+	}
+}

--- a/alien4cloud/orchestrator_test.go
+++ b/alien4cloud/orchestrator_test.go
@@ -1,0 +1,211 @@
+// Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alien4cloud
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func newHTTPServerTestOrchestrator(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case regexp.MustCompile(`.*/orchestrators/error/locations`).Match([]byte(r.URL.Path)):
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+			return
+		case regexp.MustCompile(`.*/orchestrators/.*/locations`).Match([]byte(r.URL.Path)):
+			var res struct {
+				Data []struct {
+					Location struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"location"`
+				} `json:"data"`
+			}
+			res.Data = []struct {
+				Location struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"location"`
+			}{
+				{
+					Location: struct {
+						ID   string "json:\"id\""
+						Name string "json:\"name\""
+					}{
+						ID:   "1",
+						Name: "location1",
+					},
+				},
+				{
+					Location: struct {
+						ID   string "json:\"id\""
+						Name string "json:\"name\""
+					}{
+						ID:   "2",
+						Name: "location2",
+					},
+				},
+			}
+			b, err := json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+			return
+		case regexp.MustCompile(`.*/orchestrators`).Match([]byte(r.URL.Path)):
+			sr := new(SearchRequest)
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			err = json.Unmarshal(b, sr)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if sr.Query == "error" {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"error":{"code": 404,"message":"not found"}}`))
+				return
+			}
+
+			var res struct {
+				Data struct {
+					Data []struct {
+						ID               string `json:"id"`
+						OrchestratorName string `json:"name"`
+					} `json:"data"`
+					TotalResults int `json:"totalResults"`
+				} `json:"data"`
+			}
+
+			if sr.Query != "noresults" {
+				res.Data.TotalResults = 1
+				res.Data.Data = make([]struct {
+					ID               string "json:\"id\""
+					OrchestratorName string "json:\"name\""
+				}, 0)
+				res.Data.Data = append(res.Data.Data, struct {
+					ID               string "json:\"id\""
+					OrchestratorName string "json:\"name\""
+				}{
+					ID:               "orchID1",
+					OrchestratorName: "orch1",
+				})
+				if sr.Query == "multiresults" {
+					res.Data.Data = append(res.Data.Data, struct {
+						ID               string "json:\"id\""
+						OrchestratorName string "json:\"name\""
+					}{
+						ID:               "orchID2",
+						OrchestratorName: "orch2",
+					})
+					res.Data.TotalResults = 2
+				}
+			}
+			b, err = json.Marshal(&res)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+			return
+
+		}
+		// Should not go there
+		t.Errorf("Unexpected call for request %+v", r)
+	}))
+}
+
+func Test_orchestratorService_GetOrchestratorLocations(t *testing.T) {
+	ts := newHTTPServerTestOrchestrator(t)
+	defer ts.Close()
+	type args struct {
+		orchestratorID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []Location
+		wantErr bool
+	}{
+		{"GetOrchestratorLocationsOK", args{"normal"}, []Location{{ID: "1", Name: "location1"}, {ID: "2", Name: "location2"}}, false},
+		{"GetOrchestratorLocationsError", args{"error"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &orchestratorService{
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
+			}
+			got, err := o.GetOrchestratorLocations(context.Background(), tt.args.orchestratorID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("orchestratorService.GetOrchestratorLocations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.DeepEqual(t, got, tt.want)
+
+		})
+	}
+}
+
+func Test_orchestratorService_GetOrchestratorIDbyName(t *testing.T) {
+	ts := newHTTPServerTestOrchestrator(t)
+	defer ts.Close()
+
+	type args struct {
+		orchestratorName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"GetOrchestratorIDbyNameSingle", args{"normal"}, "orchID1", false},
+		{"GetOrchestratorIDbyNameMultiResults", args{"multiresults"}, "orchID1", false},
+		{"GetOrchestratorIDbyNameNoResults", args{"noresults"}, "", true},
+		{"GetOrchestratorIDbyNameError", args{"error"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &orchestratorService{
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
+			}
+			got, err := o.GetOrchestratorIDbyName(context.Background(), tt.args.orchestratorName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("orchestratorService.GetOrchestratorIDbyName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("orchestratorService.GetOrchestratorIDbyName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/alien4cloud/topology_policies_test.go
+++ b/alien4cloud/topology_policies_test.go
@@ -104,7 +104,7 @@ func Test_topologyService_AddPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tServ := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := tServ.AddPolicy(tt.args.ctx, tt.args.a4cCtx, tt.args.policyName, tt.args.policyTypeID); (err != nil) != tt.wantErr {
 				t.Errorf("topologyService.AddPolicy() error = %v, wantErr %v", err, tt.wantErr)
@@ -205,7 +205,7 @@ func Test_topologyService_AddTargetsToPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tServ := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := tServ.AddTargetsToPolicy(tt.args.ctx, tt.args.a4cCtx, tt.args.policyName, tt.args.targets); (err != nil) != tt.wantErr {
 				t.Errorf("topologyService.AddTargetsToPolicy() error = %v, wantErr %v", err, tt.wantErr)
@@ -304,7 +304,7 @@ func Test_topologyService_DeletePolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tServ := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := tServ.DeletePolicy(tt.args.ctx, tt.args.a4cCtx, tt.args.policyName); (err != nil) != tt.wantErr {
 				t.Errorf("topologyService.DeletePolicy() error = %v, wantErr %v", err, tt.wantErr)

--- a/alien4cloud/topology_test.go
+++ b/alien4cloud/topology_test.go
@@ -46,7 +46,7 @@ func Test_topologyService_GetTopology(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			topoService := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 
 			_, err := topoService.GetTopology(tt.args.ctx, tt.args.appID, tt.args.envID)
@@ -63,7 +63,7 @@ func Test_topologyService_GetTopologies(t *testing.T) {
 	defer ts.Close()
 
 	topoService := &topologyService{
-		client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+		client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 	}
 	allTopo, err := topoService.GetTopologies(context.Background(), "")
 	if err != nil {

--- a/alien4cloud/topology_workflows_test.go
+++ b/alien4cloud/topology_workflows_test.go
@@ -129,7 +129,7 @@ func Test_topologyService_AddWorkflowActivity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tSrv := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := tSrv.AddWorkflowActivity(tt.args.ctx, tt.args.a4cCtx, tt.args.workflowName, tt.args.activity); (err != nil) != tt.wantErr {
 				t.Errorf("topologyService.AddWorkflowActivity() error = %v, wantErr %v", err, tt.wantErr)
@@ -209,7 +209,7 @@ func Test_topologyService_CreateAndDeleteWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tSrv := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			err := tSrv.CreateWorkflow(tt.args.ctx, tt.args.editorContext, tt.args.workflowName)
 			if (err != nil) != tt.wantErr {
@@ -222,7 +222,7 @@ func Test_topologyService_CreateAndDeleteWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tSrv := &topologyService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			err := tSrv.DeleteWorkflow(tt.args.ctx, tt.args.editorContext, tt.args.workflowName)
 			if (err != nil) != tt.wantErr {

--- a/alien4cloud/user_test.go
+++ b/alien4cloud/user_test.go
@@ -80,7 +80,7 @@ func Test_userService_TestCreateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.CreateUser(tt.args.ctx, tt.args.createRequest); (err != nil) != tt.wantErr {
 				t.Errorf("userService.CreateUser() error = %v, wantErr %v", err, tt.wantErr)
@@ -132,7 +132,7 @@ func Test_userService_TestUpdateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.UpdateUser(tt.args.ctx, tt.args.username, tt.args.updateRequest); (err != nil) != tt.wantErr {
 				t.Errorf("userService.UpdateUser() error = %v, wantErr %v", err, tt.wantErr)
@@ -182,7 +182,7 @@ func Test_userService_TestGetUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			userResp, err := uServ.GetUser(tt.args.ctx, tt.args.username)
 			if (err != nil) != tt.wantErr {
@@ -255,7 +255,7 @@ func Test_userService_TestGetUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			userResp, err := uServ.GetUsers(tt.args.ctx, tt.args.usernames)
 			if (err != nil) != tt.wantErr {
@@ -333,7 +333,7 @@ func Test_userService_TestSearchUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			userResp, totalNb, err := uServ.SearchUsers(tt.args.ctx, tt.args.searchRequest)
 			if err != nil {
@@ -374,7 +374,7 @@ func Test_userService_TestDeleteUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.DeleteUser(tt.args.ctx, tt.args.userName); (err != nil) != tt.wantErr {
 				t.Errorf("userService.DeleteUser() error = %v, wantErr %v", err, tt.wantErr)
@@ -424,7 +424,7 @@ func Test_userService_TestAddRemoveRole(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.AddRole(tt.args.ctx, tt.args.username, tt.args.rolename); (err != nil) != tt.wantErr {
 				t.Errorf("userService.AddRole() error = %v, wantErr %v", err, tt.wantErr)
@@ -493,7 +493,7 @@ func Test_userService_TestCreateGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			var groupID string
 			var err error
@@ -549,7 +549,7 @@ func Test_userService_TestUpdateGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.UpdateGroup(tt.args.ctx, tt.args.username, tt.args.updateRequest); (err != nil) != tt.wantErr {
 				t.Errorf("userService.UpdateGroup() error = %v, wantErr %v", err, tt.wantErr)
@@ -598,7 +598,7 @@ func Test_userService_TestGetGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			groupResp, err := uServ.GetGroup(tt.args.ctx, tt.args.groupID)
 			if (err != nil) != tt.wantErr {
@@ -671,7 +671,7 @@ func Test_userService_TestGetGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			groupResp, err := uServ.GetGroups(tt.args.ctx, tt.args.groupIDs)
 			if (err != nil) != tt.wantErr {
@@ -749,7 +749,7 @@ func Test_userService_TestSearchGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			groupResp, totalNb, err := uServ.SearchGroups(tt.args.ctx, tt.args.searchRequest)
 			if err != nil {
@@ -790,7 +790,7 @@ func Test_userService_TestDeleteGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			uServ := &userService{
-				client: restClient{Client: http.DefaultClient, baseURL: ts.URL},
+				client: &a4cClient{client: http.DefaultClient, baseURL: ts.URL},
 			}
 			if err := uServ.DeleteGroup(tt.args.ctx, tt.args.groupID); (err != nil) != tt.wantErr {
 				t.Errorf("userService.DeleteGroup() error = %v, wantErr %v", err, tt.wantErr)

--- a/alien4cloud/utils.go
+++ b/alien4cloud/utils.go
@@ -15,13 +15,9 @@
 package alien4cloud
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // ------------------------------------------
@@ -55,26 +51,4 @@ func (jar *jar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 // restrictions such as in RFC 6265.
 func (jar *jar) Cookies(u *url.URL) []*http.Cookie {
 	return jar.cookies[u.Host]
-}
-
-func processA4CResponse(response *http.Response, expectedData interface{}, expectedStatus int) error {
-	defer response.Body.Close()
-	responseBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot read the response from Alien4Cloud")
-	}
-	if response.StatusCode != expectedStatus {
-		var res struct {
-			Error Error `json:"error"`
-		}
-		err = json.Unmarshal(responseBody, &res)
-		if err != nil {
-			return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud error response")
-		}
-		return errors.New(res.Error.Message)
-	}
-	if expectedData != nil {
-		err = json.Unmarshal(responseBody, &expectedData)
-	}
-	return errors.Wrap(err, "Unable to unmarshal content of the Alien4Cloud response")
 }

--- a/examples/create-deploy-app/README.md
+++ b/examples/create-deploy-app/README.md
@@ -1,6 +1,7 @@
 # Create an application from a template and deploy it on a location
 
 This example shows how the Alien4Cloud go client can be used to:
+
 * create an application from a template in Alien4Cloud catalog
 * deploy this application on a given location (if no location is specified, the first suited location is selected)
 * while the application is being deployed, display deployment logs
@@ -30,8 +31,9 @@ go build -o deploy.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
-* credentials of a user who has the **Application Manager** role 
+* credentials of a user who has the **Application Manager** role
 * the name of the application that will be create
 * the application template in ALien4Cloud catalog that will be used
 * optionally, the name of the location where you want to deploy the application

--- a/examples/create-user/README.md
+++ b/examples/create-user/README.md
@@ -12,6 +12,7 @@ go build -o create.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of a user having the administrator
 * user properties

--- a/examples/get-application-by-id/README.md
+++ b/examples/get-application-by-id/README.md
@@ -16,6 +16,7 @@ go build -o getappbyid.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the ID of the application

--- a/examples/get-deployment-input-parameters/README.md
+++ b/examples/get-deployment-input-parameters/README.md
@@ -1,5 +1,6 @@
 # Get input properties values used for a given deployment
-This example shows how the Alien4Cloud go client can be used to get the 
+
+This example shows how the Alien4Cloud go client can be used to get the
 values of input properties used for a given deployment
 
 ## Prerequisites
@@ -16,6 +17,7 @@ go build -o get-deployment-inputs.test
 ```
 
 Now, to get a deployment input property values, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application

--- a/examples/get-input-parameters/README.md
+++ b/examples/get-input-parameters/README.md
@@ -1,4 +1,5 @@
 # Get input properties
+
 This example shows how the Alien4Cloud go client can be used to get the input
 properties of a template and in which components these properties are used
 
@@ -16,6 +17,7 @@ go build -o getinputs.test
 ```
 
 Now, to set an application input property, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application
@@ -28,5 +30,5 @@ For example :
 ./getinputs.test -url https://1.2.3.4:8088 \
                 -user myuser \
                 -password mypasswd \
-                -template name:ersion
+                -template name:version
 ```

--- a/examples/get-user/README.md
+++ b/examples/get-user/README.md
@@ -12,6 +12,7 @@ go build -o getuser.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of a user having the administrator
 * user name for which to get parameters

--- a/examples/get-workflow-status/README.md
+++ b/examples/get-workflow-status/README.md
@@ -17,6 +17,7 @@ go build -o wfstatus.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application

--- a/examples/raw-request/README.md
+++ b/examples/raw-request/README.md
@@ -1,0 +1,29 @@
+# Sending Raw Requests to Alien4cloud
+
+This example shows how to use the Alien4Cloud go client to call arbitrary REST API endpoints.
+This allows you to call endpoints not directly supported by this client.
+Typically this allows to call API endpoints coming from plugins that could not be known in advance.
+
+## Running this example
+
+Build this example:
+
+```bash
+cd raw-request
+go build -o raw.test
+```
+
+Now, run this example providing in arguments:
+
+* the Alien4Cloud URL
+* credentials of a user having the administrator
+
+For example:
+
+```bash
+./raw.test -url https://1.2.3.4:8088 \
+           -user myuser \
+           -password mypasswd
+```
+
+This will return information about the current user's status and it's roles.

--- a/examples/raw-request/main.go
+++ b/examples/raw-request/main.go
@@ -1,0 +1,97 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alien4cloud/alien4cloud-go-client/v2/alien4cloud"
+)
+
+// Command arguments
+var url, user, password string
+
+func init() {
+	// Initialize command arguments
+	flag.StringVar(&url, "url", "http://localhost:8088", "Alien4Cloud URL")
+	flag.StringVar(&user, "user", "admin", "User")
+	flag.StringVar(&password, "password", "changeme", "Password")
+
+}
+
+func main() {
+
+	// Parsing command arguments
+	flag.Parse()
+
+	client, err := alien4cloud.NewClient(url, user, password, "", true)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Timeout after one minute (this is optional you can use a context without timeout or cancelation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err = client.Login(ctx)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	request, err := client.NewRequest(ctx, "GET", "/rest/v1/auth/status", nil)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	response, err := client.Do(request)
+
+	var res struct {
+		Data struct {
+			AuthSystem     string   `json:"authSystem"`
+			GithubUsername string   `json:"githubUsername"`
+			Groups         []string `json:"groups"`
+			IsLogged       bool     `json:"isLogged"`
+			Roles          []string `json:"roles"`
+			Username       string   `json:"username"`
+		} `json:"data"`
+	}
+
+	err = alien4cloud.ReadA4CResponse(response, &res)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	fmt.Printf("User %s:\n", res.Data.Username)
+	fmt.Printf("\tGithubUsername %q\n", res.Data.GithubUsername)
+	fmt.Printf("\tAuthSystem %q\n", res.Data.AuthSystem)
+	fmt.Printf("\tIsLogged \"%v\"\n", res.Data.IsLogged)
+	if len(res.Data.Groups) > 0 {
+		fmt.Printf("\tGroups:\n")
+		for _, g := range res.Data.Groups {
+			fmt.Printf("\t\t- %q\n", g)
+		}
+	}
+	if len(res.Data.Roles) > 0 {
+		fmt.Printf("\tRoles:\n")
+		for _, r := range res.Data.Roles {
+			fmt.Printf("\t\t- %q\n", r)
+		}
+	}
+
+}

--- a/examples/run-workflow/README.md
+++ b/examples/run-workflow/README.md
@@ -17,6 +17,7 @@ go build -o run.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application

--- a/examples/search-users/README.md
+++ b/examples/search-users/README.md
@@ -12,6 +12,7 @@ go build -o search.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of a user having the administrator
 * search properties (optional):
@@ -27,4 +28,5 @@ For example:
            -password mypasswd \
            -size 10
 ```
+
 This will return the first 10 users, as well as the total number of users.

--- a/examples/search-users/main.go
+++ b/examples/search-users/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	for _, user := range users {
-		fmt.Printf("User %s, roles: %v\n", user.Username, user.Roles)
+		fmt.Printf("User %s, roles: %v\n", user.UserName, user.Roles)
 	}
 	fmt.Printf("Total number of users: %d\n", totalNumber)
 }

--- a/examples/set-input-parameters/README.md
+++ b/examples/set-input-parameters/README.md
@@ -1,4 +1,5 @@
 # Set input properties and input artifacts
+
 This example shows how the Alien4Cloud go client can be used to set an application
 input property or input artifact.
 
@@ -16,6 +17,7 @@ go build -o setinput.test
 ```
 
 Now, to set an application input property, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application
@@ -34,6 +36,7 @@ For example :
 ```
 
 To set an application input artifact, run this example, providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application

--- a/examples/undeploy-delete-app/README.md
+++ b/examples/undeploy-delete-app/README.md
@@ -17,6 +17,7 @@ go build -o undeploy.test
 ```
 
 Now, run this example providing in arguments:
+
 * the Alien4Cloud URL
 * credentials of the user who has deployed the application
 * the name of the application to undeploy and detete


### PR DESCRIPTION
Added: 

- Two new functions to the `Client` interface: 
  - `Client.NewRequest()` allows to create `http.Request`s suitable for use with `Client.Do()` function
  - `Client.Do()` allows to send a request to Alien4Cloud
- Exposed a `ReadA4CResponse()` helper function that take care of fully read and close a `http.Response` `Body`, optionally parse it into a desired structure and finally return parsed errors as golang `error`
- Introduced a `Retry` algorithm  for `Client.Do()` allowing clients of this lib to have full control over the retry mechanism while always adding a default `retryForbidden` function that will automatically perform `Client.Login()` in case of `403 Forbidden` errors
- A sample to  test this `raw-request` which will call the [`/rest/v1/auth/status`](http://alien4cloud.github.io/#/documentation/2.2.0/rest/controller_auth-controller.html) endpoint to display informations about the current user.

Updated exposed functions & Interfaces looks like:

```go
// Client is the client interface to Alien4cloud
type Client interface {
	// NewRequest allows to create a custom request to be send to Alien4Cloud
	// given a Context, method, url path and optional body.
	//
	// If the provided body is also an io.Closer, the Client Do function will automatically
	// close it.
	// The body need to be a ReadSeeker in order to rewind request on retries.
	//
	// NewRequestWithContext returns a Request suitable for use with Client.Do
	//
	// If body is of type *bytes.Reader or *strings.Reader, the returned
	// request's ContentLength is set to its
	// exact value (instead of -1)
	NewRequest(ctx context.Context, method, urlStr string, body io.ReadSeeker) (*http.Request, error)

	// Do sends an HTTP request and returns an HTTP response
	//
	// If the returned error is nil, the Response will contain a non-nil
	// Body which the user is expected to close. If the Body is not both
	// read to EOF and closed, the Client's underlying RoundTripper
	// (typically Transport) may not be able to re-use a persistent TCP
	// connection to the server for a subsequent "keep-alive" request.
	// ReadA4CResponse() helper function is typically used to do this.
	//
	// The request Body, if non-nil, will be closed by the Do function
	// even on errors.
	//
	// Optional Retry functions may be provided. Those functions are executed sequentially to determine
	// if and how a request should be retried. See Retry documentation for more details.
	// Note: a special Retry function is always added at the end of the retries list. It will
	// automatically retry 403 Forbidden errors by trying to call Client.Login first.
	// This is for backward compatibility.
	Do(req *http.Request, retries ...Retry) (*http.Response, error)

	// Other functions omitted 
}


// Retry is a function called after sending a request.
// It allows to perform actions based on the given response before re-sending a request.
// A typical usecase is to automatically call the Client.Login() function when receiving a 403 Forbidden response.
//
// It is possible to alter the request to be send by returning an updated request. But in most cases
// the given original request can safely be returned as it. This framework take care of rewinding the request body
// before giving it to retry functions.
//
// The retry algorithm is:
// - If a retry function returns an error the retry process is stopped and this error is returned
// - If a retry function returns a nil request the retry process continue and consider the next available retry function
// - If a retry function returns a non-nil request this request is used in a Client.Do() call
//
// Note: It is critical that if the response body is read in a retry function it should not be closed
// and somehow rewind to the begining.
type Retry func(client Client, request *http.Request, response *http.Response) (*http.Request, error)

// ReadA4CResponse is an helper function that allow to fully read and close a response body and
// unmarshal its json content into a provided data structure.
// If response status code is greather or equal to 400 it automatically parse an error response and
// returns it as a non-nil error.
func ReadA4CResponse(response *http.Response, data interface{}) error

```


Closes #29 