### PR TITLE
Deploy becomes an option of the create and deploy example

### DIFF
--- a/examples/create-deploy-app/README.md
+++ b/examples/create-deploy-app/README.md
@@ -3,9 +3,9 @@
 This example shows how the Alien4Cloud go client can be used to:
 
 * create an application from a template in Alien4Cloud catalog
-* deploy this application on a given location (if no location is specified, the first suited location is selected)
-* while the application is being deployed, display deployment logs
-* once done, display application components variables, if any
+* optionally, deploy this application on a given location (if no location is specified, the first suited location is selected)
+  * while the application is being deployed, display deployment logs
+  * once done, display application components variables, if any
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ Build this example:
 
 ```bash
 cd examples/create-deploy-app
-go build -o deploy.test
+go build -o create.test
 ```
 
 Now, run this example providing in arguments:
@@ -36,15 +36,17 @@ Now, run this example providing in arguments:
 * credentials of a user who has the **Application Manager** role
 * the name of the application that will be create
 * the application template in ALien4Cloud catalog that will be used
+* specify you want to deploy the crrated applicatiob
 * optionally, the name of the location where you want to deploy the application
   (by default, the first location suited for the deployment will be selected)
 
 ```bash
-./deploy.test -url https://1.2.3.4:8088 \
+./create.test -url https://1.2.3.4:8088 \
               -user myuser \
               -password mypasswd \
               -app myapp \
-              -template org.ystia.samples.topologies.welcome_basic
+              -template org.ystia.samples.topologies.welcome_basic \
+              -deploy
 ```
 
 This will create the application, deploy it on a location, print deployment logs,

--- a/examples/create-deploy-app/main.go
+++ b/examples/create-deploy-app/main.go
@@ -27,6 +27,7 @@ import (
 
 // Command arguments
 var url, user, password, appName, appTemplate, locationName string
+var deploy bool
 
 func init() {
 	// Initialize command arguments
@@ -35,7 +36,9 @@ func init() {
 	flag.StringVar(&password, "password", "changeme", "Password")
 	flag.StringVar(&appName, "app", "", "Name of the application to create")
 	flag.StringVar(&appTemplate, "template", "", "Name of the topology template to use")
+	flag.BoolVar(&deploy, "deploy", false, "Deploy the application")
 	flag.StringVar(&locationName, "location", "", "Name of the location where to deploy the application")
+
 }
 
 func main() {
@@ -70,6 +73,11 @@ func main() {
 		log.Panic(err)
 	}
 
+	if !deploy {
+		log.Printf("Application created")
+		return
+	}
+
 	envID, err := client.ApplicationService().GetEnvironmentIDbyName(ctx, appID, alien4cloud.DefaultEnvironmentName)
 	if err != nil {
 		log.Panic(err)
@@ -90,6 +98,9 @@ func main() {
 		time.Sleep(5 * time.Second)
 
 		a4cLogs, nbLogs, err := client.LogService().GetLogsOfApplication(ctx, appID, envID, filters, logIndex)
+		if err != nil {
+			log.Panic(err)
+		}
 		if nbLogs > 0 {
 			logIndex = logIndex + nbLogs
 			for idx := 0; idx < nbLogs; idx++ {


### PR DESCRIPTION
Updated the example creating and deploying an application, to be able to just create the application.
This is useful when there is the need to set input after the creation and before dedeployment