### PR TITLE
Update set-input-parameters examples

### DIFF
--- a/examples/set-input-parameters/README.md
+++ b/examples/set-input-parameters/README.md
@@ -22,7 +22,8 @@ Now, to set an application input property, run this example providing in argumen
 * credentials of the user who has deployed the application
 * the name of the application
 * the input property name
-* the input property value.
+* the input property value or a path to a file containing this value (usefull for json values)
+* the type of value: string (default), map of strings or array of strings.
 
 For example :
 
@@ -33,6 +34,18 @@ For example :
                 -app MyApp \
                 -property myprop \
                 -value myval
+```
+
+or for property value being a map of strings provided in a file:
+
+```bash
+./setinput.test -url https://1.2.3.4:8088 \
+                -user myuser \
+                -password mypasswd \
+                -app MyApp \
+                -property myprop \
+                -value_type map \
+                -value_file test.json
 ```
 
 To set an application input artifact, run this example, providing in arguments:


### PR DESCRIPTION
Minor update to be able to provide not only string values, but also a map of strings or an array of strings