### PR TITLE
Get exections directly by ID in alien API

### DIFF
--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -73,8 +73,13 @@ type DeploymentService interface {
 	// - query allows to search a specific execution but may be empty
 	// - from and size allows to paginate results
 	GetExecutions(ctx context.Context, deploymentID, query string, from, size int) ([]Execution, FacetedSearchResult, error)
+
+	// GetExecutionByID returns details of a given execution
+	// Returns an error if no execution with such ID was found
+	GetExecutionByID(ctx context.Context, executionID string) (Execution, error)
 	// GetExecution returns details of a given execution
 	// Returns an error if no execution with such ID was found
+	// Deprecated: Prefer GetExecutionByID instead
 	GetExecution(ctx context.Context, deploymentID, workflowName, executionID string) (Execution, error)
 
 	// Cancels execution for given environmentID and executionID
@@ -605,14 +610,9 @@ func (d *deploymentService) RunWorkflowAsync(ctx context.Context, a4cAppID strin
 	// Let a4c time to register execution (500ms is not enough)
 	<-time.After(time.Second)
 	// now monitor workflow execution
-	deploymentID, err := d.GetCurrentDeploymentID(ctx, a4cAppID, a4cEnvID)
-	if err != nil {
-		return "", errors.Wrapf(err, "Unable to get deployment ID for application %s env %s", a4cAppID, a4cEnvID)
-	}
-
 	go func() {
 		for {
-			exec, err := d.GetExecution(ctx, deploymentID, workflowName, res.Data)
+			exec, err := d.GetExecutionByID(ctx, res.Data)
 			if err != nil {
 				callback(nil, err)
 				return

--- a/alien4cloud/deployment.go
+++ b/alien4cloud/deployment.go
@@ -79,6 +79,7 @@ type DeploymentService interface {
 	GetExecutionByID(ctx context.Context, executionID string) (Execution, error)
 	// GetExecution returns details of a given execution
 	// Returns an error if no execution with such ID was found
+	//
 	// Deprecated: Prefer GetExecutionByID instead
 	GetExecution(ctx context.Context, deploymentID, workflowName, executionID string) (Execution, error)
 

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -74,6 +74,7 @@ func (d *deploymentService) GetExecutionByID(ctx context.Context, executionID st
 
 // GetExecution returns details of a given execution
 // Returns an error if no execution with such ID was found
+//
 // Deprecated: Prefer GetExecutionByID instead
 func (d *deploymentService) GetExecution(ctx context.Context, deploymentID, workflowName, executionID string) (Execution, error) {
 	return d.GetExecutionByID(ctx, executionID)

--- a/alien4cloud/deployment_execution.go
+++ b/alien4cloud/deployment_execution.go
@@ -48,31 +48,35 @@ func (d *deploymentService) GetExecutions(ctx context.Context, deploymentID, que
 
 // GetExecution returns details of a given execution
 // Returns an error if no execution with such ID was found
-func (d *deploymentService) GetExecution(ctx context.Context, deploymentID, workflowName, executionID string) (Execution, error) {
-	startIndex := 0
-	size := 50
-	var exec Execution
-	var err error
-	for {
-		execs, res, err := d.GetExecutions(ctx, deploymentID, workflowName, startIndex, size)
-		if err != nil {
-			break
-		}
-		for _, e := range execs {
-			if e.ID == executionID {
-				exec = e
-				return exec, err
-			}
-		}
-		// Execution not found in this range
-		if res.TotalResults < (size + startIndex) {
-			return exec, errors.Errorf("Found no execution with ID %s for deployment %s workflow %s",
-				executionID, deploymentID, workflowName)
-		}
-		startIndex = startIndex + size
-		size = res.TotalResults
+func (d *deploymentService) GetExecutionByID(ctx context.Context, executionID string) (Execution, error) {
+	u := fmt.Sprintf("%s/executions/%s", a4CRestAPIPrefix, executionID)
+
+	request, err := d.client.NewRequest(ctx,
+		"GET",
+		u,
+		nil)
+	if err != nil {
+		return Execution{}, errors.Wrapf(err, "Failed to get execution %q", executionID)
 	}
-	return exec, err
+
+	response, err := d.client.Do(request)
+	if err != nil {
+		return Execution{}, errors.Wrapf(err, "Cannot send request to get execution %q", executionID)
+	}
+
+	var res struct {
+		Execution `json:"data"`
+	}
+
+	err = ReadA4CResponse(response, &res)
+	return res.Execution, err
+}
+
+// GetExecution returns details of a given execution
+// Returns an error if no execution with such ID was found
+// Deprecated: Prefer GetExecutionByID instead
+func (d *deploymentService) GetExecution(ctx context.Context, deploymentID, workflowName, executionID string) (Execution, error) {
+	return d.GetExecutionByID(ctx, executionID)
 }
 
 func (d *deploymentService) CancelExecution(ctx context.Context, environmentID string, executionID string) error {

--- a/alien4cloud/deployment_test.go
+++ b/alien4cloud/deployment_test.go
@@ -725,17 +725,17 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":"%s"}`, matches[1])))
 			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "wf":
+		case regexp.MustCompile(`.*/executions/execID`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"execID","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"wf","workflowName":"wf","displayWorkflowName":"wf","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"execID","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"wf","workflowName":"wf","displayWorkflowName":"wf","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}}`))
 			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "execCancel":
+		case regexp.MustCompile(`.*/executions/execCancel`).Match([]byte(r.URL.Path)) && r.URL.Query().Get("query") == "execCancel":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"execCancel","workflowName":"execCancel","displayWorkflowName":"execCancel","startDate":1578949107377,"endDate":1578949125749,"status":"RUNNING","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"execCancel","workflowName":"execCancel","displayWorkflowName":"execCancel","startDate":1578949107377,"endDate":1578949125749,"status":"RUNNING","hasFailedTasks":false}}`))
 			return
-		case regexp.MustCompile(`.*/executions/search`).Match([]byte(r.URL.Path)):
+		case regexp.MustCompile(`.*/executions/.*`).Match([]byte(r.URL.Path)):
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"data":{"types":["execution"],"data":[{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}],"queryDuration":1,"totalResults":3,"from":1,"to":1,"facets":null},"error":null}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"7459ca00-f98f-47f1-a7e8-4d779d65253a","deploymentId":"4186a188-24a4-4910-9d7b-207ca09f98e3","workflowId":"stopWebServer","workflowName":"stopWebServer","displayWorkflowName":"stopWebServer","startDate":1578949107377,"endDate":1578949125749,"status":"SUCCEEDED","hasFailedTasks":false}}`))
 			return
 		}
 
@@ -760,7 +760,7 @@ func Test_deploymentService_RunWorkflow(t *testing.T) {
 			&Execution{ID: "execID", DeploymentID: "4186a188-24a4-4910-9d7b-207ca09f98e3", WorkflowID: "wf", WorkflowName: "wf", DisplayWorkflowName: "wf", Status: "SUCCEEDED", HasFailedTasks: false},
 			false,
 		},
-		{"BadExecID", args{context.Background(), "BadExecID", "env", "wf", 5 * time.Minute}, nil, true},
+		{"BadExecID", args{context.Background(), "error", "env", "wf", 5 * time.Minute}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Instead of searching for a given execution ID within all executions of a workflow.

We expect better performances when a workflow was run many times in the same deployment.


For the record here is a sample of Alien response on the given API endpoint

Success:

```json
{
  "data": {
    "id": "e66c513d-a828-458c-9f07-9bfff54732ba",
    "deploymentId": "ced9c6aa-eacd-4a92-9193-aa42bb22f1ce",
    "workflowId": "install",
    "workflowName": "install",
    "displayWorkflowName": "install",
    "startDate": 1620416128001,
    "endDate": 1620416138645,
    "status": "SUCCEEDED",
    "hasFailedTasks": false
  },
  "error": null
}
```

Exec not found:

```json
{
  "data": null,
  "error": {
    "code": 504,
    "message": "Execution with id <dfsfs> was not found."
  }
}
```

Fixes #43