### PR TITLE
Allow to search for environments for a given application

### DIFF
--- a/a4cmocks/application.go
+++ b/a4cmocks/application.go
@@ -170,6 +170,22 @@ func (mr *MockApplicationServiceMockRecorder) SearchApplications(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchApplications", reflect.TypeOf((*MockApplicationService)(nil).SearchApplications), arg0, arg1)
 }
 
+// SearchEnvironments mocks base method.
+func (m *MockApplicationService) SearchEnvironments(arg0 context.Context, arg1 string, arg2 alien4cloud.SearchRequest) ([]alien4cloud.Environment, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchEnvironments", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]alien4cloud.Environment)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SearchEnvironments indicates an expected call of SearchEnvironments.
+func (mr *MockApplicationServiceMockRecorder) SearchEnvironments(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchEnvironments", reflect.TypeOf((*MockApplicationService)(nil).SearchEnvironments), arg0, arg1, arg2)
+}
+
 // SetTagToApplication mocks base method.
 func (m *MockApplicationService) SetTagToApplication(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/alien4cloud/alien4cloud_structs.go
+++ b/alien4cloud/alien4cloud_structs.go
@@ -196,8 +196,8 @@ type SimpleMark struct {
 // SearchRequest is the representation of a request to search objects such as topologies, orchestrators in the A4C catalog
 type SearchRequest struct {
 	Query   string              `json:"query,omitempty"`
-	From    int                 `json:"from,omitempty"`
-	Size    int                 `json:"size,omitempty"`
+	From    int                 `json:"from"`
+	Size    int                 `json:"size"`
 	Filters map[string][]string `json:"filters,omitempty"`
 }
 
@@ -725,4 +725,18 @@ type Group struct {
 	Description string   `json:"description,omitempty"`
 	Users       []string `json:"users,omitempty"`
 	Roles       []string `json:"roles,omitempty"`
+}
+
+// Environment holds properties of an Alien4Cloud environment
+type Environment struct {
+	ID                 string              `json:"id"`
+	Name               string              `json:"name"`
+	Status             string              `json:"status,omitempty"`
+	ApplicationID      string              `json:"applicationId,omitempty"`
+	CurrentVersionName string              `json:"currentVersionName,omitempty"`
+	DeployedVersion    string              `json:"deployedVersion,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	EnvironmentType    string              `json:"environmentType,omitempty"`
+	UserRoles          map[string][]string `json:"userRoles,omitempty"`
+	GroupRoles         map[string][]string `json:"GroupRoles,omitempty"`
 }


### PR DESCRIPTION
- Added an `Environment` structure
- Add a `SearchEnvironments(ctx context.Context, applicationID string, searchRequest SearchRequest) ([]Environment, int, error)` function within the `ApplicationService`
- Always serialize `from` & `size` attributes of a `SearchRequest` as they are required for some endpoints

Fixes #50 